### PR TITLE
Change furnace burner item checks to null instead of 0

### DIFF
--- a/src/main/java/com/mrh0/createaddition/blocks/base/AbstractBurnerBlockEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/base/AbstractBurnerBlockEntity.java
@@ -116,7 +116,7 @@ public abstract class AbstractBurnerBlockEntity extends SmartTileEntity implemen
 	}
 
 	public int getBurnDuration(ItemStack stack) {
-		if (stack.isEmpty()) {
+		if (stack.isEmpty() || FuelRegistry.INSTANCE.get(stack.getItem()) == null) {
 			return 0;
 		} else {
 			return FuelRegistry.INSTANCE.get(stack.getItem());
@@ -173,7 +173,7 @@ public abstract class AbstractBurnerBlockEntity extends SmartTileEntity implemen
 
 	public boolean canPlaceItem(int index, ItemStack stack) {
 		ItemStack itemstack = this.items.get(0);
-		return FuelRegistry.INSTANCE.get(stack.getItem()) > 0
+		return FuelRegistry.INSTANCE.get(stack.getItem()) != null
 				|| stack.is(Items.BUCKET) && !itemstack.is(Items.BUCKET);
 	}
 


### PR DESCRIPTION
FuelRegistry returns null and causes a game crash if a non-fuel item is inserted into a furnace burner (#262).
This makes the furnace burner check if the fuel value is null instead of 0 to fix the crash (null fuel means not accepted)