### PR TITLE
Update to be compatible with Create 0.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,7 @@ dependencies {
     // Specify the version of Minecraft to use. If this is any group other than 'net.minecraft', it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.18.2-40.0.41'
+    minecraft 'net.minecraftforge:forge:1.18.2-40.1.54'
 
     // Real mod deobf dependency examples - these get remapped to your current mappings
     // compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api") // Adds JEI API as a compile dependency
@@ -188,8 +188,8 @@ dependencies {
 	compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}:api")
     runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}")
 
-    implementation fg.deobf("curse.maven:create-328085:3737418")
-    implementation fg.deobf("curse.maven:flywheel-486392:3737402")
+    implementation fg.deobf("curse.maven:create-328085:3864525")
+    implementation fg.deobf("curse.maven:flywheel-486392:3864518")
 	//implementation fg.deobf("curse.maven:immersive-engineering-231951:3579169")
     implementation fg.deobf("curse.maven:cc-tweaked-282001:3709268")
 	implementation fg.deobf("curse.maven:applied-energistics-2-223794:3736294")

--- a/src/main/java/com/mrh0/createaddition/CreateAddition.java
+++ b/src/main/java/com/mrh0/createaddition/CreateAddition.java
@@ -2,7 +2,6 @@ package com.mrh0.createaddition;
 
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraft.commands.CommandSource;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffect;
@@ -29,14 +28,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.mojang.brigadier.CommandDispatcher;
-import com.mrh0.createaddition.blocks.crude_burner.CrudeBurner;
-import com.mrh0.createaddition.blocks.furnace_burner.FurnaceBurner;
 import com.mrh0.createaddition.commands.CCApiCommand;
 import com.mrh0.createaddition.config.Config;
 import com.mrh0.createaddition.groups.ModGroup;
 import com.mrh0.createaddition.index.CABlocks;
 import com.mrh0.createaddition.index.CAEffects;
-import com.mrh0.createaddition.index.CAEntities;
 import com.mrh0.createaddition.index.CAFluids;
 import com.mrh0.createaddition.index.CAItemProperties;
 import com.mrh0.createaddition.index.CAItems;
@@ -47,13 +43,8 @@ import com.mrh0.createaddition.index.CATileEntities;
 import com.mrh0.createaddition.network.EnergyNetworkPacket;
 import com.mrh0.createaddition.network.ObservePacket;
 import com.mrh0.createaddition.network.RemoveConnectorPacket;
-import com.simibubi.create.AllBlocks;
-import com.simibubi.create.content.contraptions.components.flywheel.engine.FurnaceEngineInteractions;
-import com.simibubi.create.content.contraptions.components.flywheel.engine.FurnaceEngineInteractions.HeatSource;
 import com.simibubi.create.foundation.data.CreateRegistrate;
 import com.simibubi.create.repack.registrate.util.nullness.NonNullSupplier;
-
-import net.minecraftforge.registries.IRegistryDelegate;
 
 @Mod(CreateAddition.MODID)
 public class CreateAddition {
@@ -139,8 +130,8 @@ public class CreateAddition {
         Network.registerMessage(i++, EnergyNetworkPacket.class, EnergyNetworkPacket::encode, EnergyNetworkPacket::decode, EnergyNetworkPacket::handle);
         Network.registerMessage(i++, RemoveConnectorPacket.class, RemoveConnectorPacket::encode, RemoveConnectorPacket::decode, RemoveConnectorPacket::handle);
         
-        
-        
+        // Create 0.5 removed Furnace Engine
+        /*
         FurnaceEngineInteractions.registerHandler(CABlocks.FURNACE_BURNER.get().delegate, FurnaceEngineInteractions.InteractionHandler.of(
        		 s -> s.getBlock() instanceof FurnaceBurner && s.hasProperty(FurnaceBurner.LIT) ? 
        		 (s.getValue(FurnaceBurner.LIT) ? HeatSource.ACTIVE : HeatSource.VALID) : HeatSource.EMPTY, s -> (float)(double)Config.FURNACE_BURNER_ENGINE_SPEED.get()));
@@ -148,7 +139,7 @@ public class CreateAddition {
         FurnaceEngineInteractions.registerHandler(CABlocks.CRUDE_BURNER.get().delegate, FurnaceEngineInteractions.InteractionHandler.of(
           		 s -> s.getBlock() instanceof CrudeBurner && s.hasProperty(CrudeBurner.LIT) ? 
           	       		 (s.getValue(CrudeBurner.LIT) ? HeatSource.ACTIVE : HeatSource.VALID) : HeatSource.EMPTY, s -> (float)(double)Config.CRUDE_BURNER_ENGINE_SPEED.get()));
-        
+        */
     	System.out.println("Create Crafts & Addition Initialized!");
     }
     

--- a/src/main/java/com/mrh0/createaddition/blocks/alternator/AlternatorTileEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/alternator/AlternatorTileEntity.java
@@ -52,7 +52,7 @@ public class AlternatorTileEntity extends KineticTileEntity {
 		//tooltip.add(new StringTextComponent(spacing).append(new StringTextComponent(" " + Multimeter.getString(energy) + "fe").formatted(TextFormatting.AQUA)));
 		tooltip.add(new TextComponent(spacing).append(new TranslatableComponent(CreateAddition.MODID + ".tooltip.energy.production").withStyle(ChatFormatting.GRAY)));
 		tooltip.add(new TextComponent(spacing).append(new TextComponent(" " + Util.format(getEnergyProductionRate((int) (isSpeedRequirementFulfilled() ? getSpeed() : 0))) + "fe/t ") // fix
-				.withStyle(ChatFormatting.AQUA)).append(Lang.translate("gui.goggles.at_current_speed").withStyle(ChatFormatting.DARK_GRAY)));
+				.withStyle(ChatFormatting.AQUA)).append(Lang.translateDirect("gui.goggles.at_current_speed").withStyle(ChatFormatting.DARK_GRAY)));
 		added = true;
 		return added;
 	}

--- a/src/main/java/com/mrh0/createaddition/blocks/electric_motor/ElectricMotorTileEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/electric_motor/ElectricMotorTileEntity.java
@@ -73,11 +73,11 @@ public class ElectricMotorTileEntity extends GeneratingKineticTileEntity {
 		CenteredSideValueBoxTransform slot =
 			new CenteredSideValueBoxTransform((motor, side) -> motor.getValue(ElectricMotorBlock.FACING) == side.getOpposite());
 
-		generatedSpeed = new ScrollValueBehaviour(Lang.translate("generic.speed"), this, slot);
+		generatedSpeed = new ScrollValueBehaviour(Lang.translateDirect("generic.speed"), this, slot);
 		generatedSpeed.between(-RPM_RANGE, RPM_RANGE);
 		generatedSpeed.value = DEFAULT_SPEED;
 		generatedSpeed.scrollableValue = DEFAULT_SPEED;
-		generatedSpeed.withUnit(i -> Lang.translate("generic.unit.rpm"));
+		generatedSpeed.withUnit(i -> Lang.translateDirect("generic.unit.rpm"));
 		generatedSpeed.withCallback(i -> this.updateGeneratedRotation(i));
 		generatedSpeed.withStepFunction(ElectricMotorTileEntity::step);
 		behaviours.add(generatedSpeed);
@@ -112,7 +112,7 @@ public class ElectricMotorTileEntity extends GeneratingKineticTileEntity {
 		boolean added = super.addToGoggleTooltip(tooltip, isPlayerSneaking);
 		tooltip.add(new TextComponent(spacing).append(new TranslatableComponent(CreateAddition.MODID + ".tooltip.energy.consumption").withStyle(ChatFormatting.GRAY)));
 		tooltip.add(new TextComponent(spacing).append(new TextComponent(" " + Util.format(getEnergyConsumptionRate(generatedSpeed.getValue())) + "fe/t ")
-				.withStyle(ChatFormatting.AQUA)).append(Lang.translate("gui.goggles.at_current_speed").withStyle(ChatFormatting.DARK_GRAY)));
+				.withStyle(ChatFormatting.AQUA)).append(Lang.translateDirect("gui.goggles.at_current_speed").withStyle(ChatFormatting.DARK_GRAY)));
 		added = true;
 		return added;
 	}

--- a/src/main/java/com/mrh0/createaddition/blocks/heater/HeaterTileEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/heater/HeaterTileEntity.java
@@ -8,7 +8,6 @@ import com.mrh0.createaddition.blocks.base.AbstractBurnerBlockEntity;
 import com.mrh0.createaddition.config.Config;
 import com.mrh0.createaddition.energy.BaseElectricTileEntity;
 import com.mrh0.createaddition.util.Util;
-import com.simibubi.create.AllBlocks;
 import com.simibubi.create.content.contraptions.goggles.IHaveGoggleInformation;
 
 import net.minecraft.ChatFormatting;
@@ -129,9 +128,12 @@ public class HeaterTileEntity extends BaseElectricTileEntity implements IHaveGog
 	public boolean hasFurnaceEngine() {
 		Direction dir = getBlockState().getValue(HeaterBlock.FACING);
 		BlockPos origin = worldPosition.relative(dir);
+		// Furnace Engine no longer exists in 0.5
+		/*
 		for(Direction d : Direction.values())
 			if(level.getBlockState(origin.relative(d)).getBlock() == AllBlocks.FURNACE_ENGINE.get())
 				return true;
+		 */
 		return false;
 	}
 	

--- a/src/main/java/com/mrh0/createaddition/compat/jei/CARecipeCategory.java
+++ b/src/main/java/com/mrh0/createaddition/compat/jei/CARecipeCategory.java
@@ -3,9 +3,9 @@ package com.mrh0.createaddition.compat.jei;
 import com.mrh0.createaddition.CreateAddition;
 import com.simibubi.create.compat.jei.category.CreateRecipeCategory;
 import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.Recipe;
 
 public abstract class CARecipeCategory<T extends Recipe<?>> extends CreateRecipeCategory<T> {
@@ -16,8 +16,8 @@ public abstract class CARecipeCategory<T extends Recipe<?>> extends CreateRecipe
 
 	@Override
 	public void setCategoryId(String name) {
-		this.uid = new ResourceLocation(CreateAddition.MODID, name);
 		this.name = name;
+		this.type = RecipeType.create(CreateAddition.MODID, name, this.getRecipeClass());
 	}
 	
 	@Override

--- a/src/main/java/com/mrh0/createaddition/compat/jei/ChargingCategory.java
+++ b/src/main/java/com/mrh0/createaddition/compat/jei/ChargingCategory.java
@@ -1,22 +1,16 @@
 package com.mrh0.createaddition.compat.jei;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mrh0.createaddition.index.CABlocks;
 import com.mrh0.createaddition.recipe.charging.ChargingRecipe;
-import com.mrh0.createaddition.recipe.rolling.RollingRecipe;
 import com.mrh0.createaddition.util.Util;
 import com.simibubi.create.foundation.gui.AllGuiTextures;
 
-import mezz.jei.api.constants.VanillaTypes;
-import mezz.jei.api.gui.IRecipeLayout;
-import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
-import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
 import net.minecraft.client.Minecraft;
-import net.minecraft.network.chat.TranslatableComponent;
-import net.minecraft.world.item.ItemStack;
 
 public class ChargingCategory extends CARecipeCategory<ChargingRecipe> {
 
@@ -32,37 +26,24 @@ public class ChargingCategory extends CARecipeCategory<ChargingRecipe> {
 	}
 
 	@Override
-	public void setIngredients(ChargingRecipe recipe, IIngredients ingredients) {
-		ingredients.setInputIngredients(recipe.getIngredients());
-		ArrayList<ItemStack> stacks = new ArrayList<>();
-		stacks.add(recipe.getResultItem());
-		ingredients.setOutputs(VanillaTypes.ITEM, stacks);
+	public void setRecipe(IRecipeLayoutBuilder builder, ChargingRecipe recipe, IFocusGroup focuses) {
+		builder
+				.addSlot(RecipeIngredientRole.INPUT, 15, 9)
+				.setBackground(getRenderedSlot(), -1, -1)
+				.addIngredients(recipe.ingredient);
+
+		builder
+				.addSlot(RecipeIngredientRole.OUTPUT, 140, 28)
+				.setBackground(getRenderedSlot(), -1, -1)
+				.addItemStack(recipe.getResultItem());
 	}
 
 	@Override
-	public void setRecipe(IRecipeLayout recipeLayout, ChargingRecipe recipe, IIngredients ingredients) {
-		IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-		itemStacks.init(0, true, 14, 8);
-		itemStacks.set(0, recipe.ingredient.getItems()[0]);
-
-		ItemStack result = recipe.getResultItem();
-		int yOffset = (0 / 2) * -19;
-
-		itemStacks.init(1, false, 139, 27 + yOffset);
-		itemStacks.set(1, result);
-
-		//addStochasticTooltip(itemStacks, results);
-	}
-
-	@Override
-	public void draw(ChargingRecipe recipe, PoseStack matrixStack, double mouseX, double mouseY) {
-		AllGuiTextures.JEI_SLOT.render(matrixStack, 14, 8);
+	public void draw(ChargingRecipe recipe, IRecipeSlotsView iRecipeSlotsView, PoseStack matrixStack, double mouseX, double mouseY) {
 		AllGuiTextures.JEI_ARROW.render(matrixStack, 85, 32);
 		AllGuiTextures.JEI_DOWN_ARROW.render(matrixStack, 43, 4);
 		tesla_coil.draw(matrixStack, 48, 27);
 		
 		Minecraft.getInstance().font.draw(matrixStack, Util.format(recipe.energy) + "fe", 86, 9, 4210752);
-
-		getRenderedSlot(recipe, 0).render(matrixStack, 139, 27);
 	}
 }

--- a/src/main/java/com/mrh0/createaddition/compat/jei/CreateAdditionJEI.java
+++ b/src/main/java/com/mrh0/createaddition/compat/jei/CreateAdditionJEI.java
@@ -14,7 +14,6 @@ import com.mrh0.createaddition.index.CAItems;
 import com.mrh0.createaddition.recipe.charging.ChargingRecipe;
 import com.mrh0.createaddition.recipe.crude_burning.CrudeBurningRecipe;
 import com.mrh0.createaddition.recipe.rolling.RollingRecipe;
-import com.simibubi.create.AllItems;
 import com.simibubi.create.Create;
 import com.simibubi.create.compat.jei.ConversionRecipe;
 import com.simibubi.create.compat.jei.category.CreateRecipeCategory;
@@ -107,7 +106,7 @@ public class CreateAdditionJEI implements IModPlugin {
 		}
 
 		CategoryBuilder<T> recipes(RecipeType<?> recipeTypeEntry) {
-			category.recipes.add(() -> findRecipesByType(recipeTypeEntry));
+			category.recipes.add(() -> (List<T>) findRecipesByType(recipeTypeEntry));
 			return this;
 		}
 

--- a/src/main/java/com/mrh0/createaddition/compat/jei/CrudeBurningCategory.java
+++ b/src/main/java/com/mrh0/createaddition/compat/jei/CrudeBurningCategory.java
@@ -2,23 +2,17 @@ package com.mrh0.createaddition.compat.jei;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mrh0.createaddition.index.CABlocks;
 import com.mrh0.createaddition.recipe.crude_burning.CrudeBurningRecipe;
-import com.simibubi.create.foundation.fluid.FluidIngredient;
-import com.simibubi.create.foundation.gui.AllGuiTextures;
 
 import mezz.jei.api.constants.VanillaTypes;
-import mezz.jei.api.gui.IRecipeLayout;
-import mezz.jei.api.gui.ingredient.IGuiFluidStackGroup;
-import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
 import net.minecraft.client.Minecraft;
-import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.TranslatableComponent;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.fluids.FluidStack;
 
 public class CrudeBurningCategory extends CARecipeCategory<CrudeBurningRecipe> {
@@ -33,40 +27,20 @@ public class CrudeBurningCategory extends CARecipeCategory<CrudeBurningRecipe> {
 	}
 
 	@Override
-	public void setIngredients(CrudeBurningRecipe recipe, IIngredients ingredients) {
-		ingredients.setInputIngredients(new ArrayList<Ingredient>());
-		ingredients.setOutputs(VanillaTypes.ITEM, new ArrayList<ItemStack>());
-		ingredients.setInputLists(VanillaTypes.FLUID, NonNullList.of(recipe.getFluidIngredient().getMatchingFluidStacks()));
-	}
-
-	@Override
-	public void setRecipe(IRecipeLayout recipeLayout, CrudeBurningRecipe recipe, IIngredients ingredients) {
-		IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
-		
-		NonNullList<FluidIngredient> fluidIngredients = NonNullList.of(recipe.getFluidIngredient());
-		
+	public void setRecipe(IRecipeLayoutBuilder builder, CrudeBurningRecipe recipe, IFocusGroup focuses) {
 		List<FluidStack> out = new ArrayList<FluidStack>();
-		
-		fluidStacks.init(0, true, 81, 7);
-		fluidStacks.set(0, withImprovedVisibility(recipe.getFluidIngredient().getMatchingFluidStacks()
-				.stream()
-				.map(fluid -> {
-					out.add(fluid);
-					return fluid;
-				})
-				.collect(Collectors.toList())));
-
-		addFluidTooltip(fluidStacks, fluidIngredients, out);
+		builder
+				.addSlot(RecipeIngredientRole.INPUT, 82, 8)
+				.setBackground(getRenderedSlot(), -1, -1)
+				.addIngredients(
+						VanillaTypes.FLUID,
+						withImprovedVisibility(recipe.getFluidIngredient().getMatchingFluidStacks())
+				)
+				.addTooltipCallback(addFluidTooltip());
 	}
 
 	@Override
 	public void draw(CrudeBurningRecipe recipe, PoseStack matrixStack, double mouseX, double mouseY) {
-		//AllGuiTextures.JEI_SLOT.draw(matrixStack, 14, 8);
-		//AllGuiTextures.JEI_ARROW.draw(matrixStack, 85, 32);
-		//AllGuiTextures.JEI_DOWN_ARROW.draw(matrixStack, 43, 4);
-
-		AllGuiTextures.JEI_SLOT.render(matrixStack, 80, 6);
-
 		Minecraft.getInstance().font.draw(matrixStack, new TranslatableComponent("createaddition.recipe.crude_burning.burn_time").getString(Integer.MAX_VALUE) + ": " + ((double)recipe.getBurnTime()/20d)+"s", 9, 34, 4210752);
 	}
 }

--- a/src/main/java/com/mrh0/createaddition/compat/jei/RollingMillCategory.java
+++ b/src/main/java/com/mrh0/createaddition/compat/jei/RollingMillCategory.java
@@ -8,11 +8,9 @@ import com.mrh0.createaddition.index.CABlocks;
 import com.mrh0.createaddition.recipe.rolling.RollingRecipe;
 import com.simibubi.create.foundation.gui.AllGuiTextures;
 
-import mezz.jei.api.constants.VanillaTypes;
-import mezz.jei.api.gui.IRecipeLayout;
-import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
-import mezz.jei.api.ingredients.IIngredients;
-import net.minecraft.world.item.ItemStack;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
 
 public class RollingMillCategory extends CARecipeCategory<RollingRecipe> {
 
@@ -28,35 +26,22 @@ public class RollingMillCategory extends CARecipeCategory<RollingRecipe> {
 	}
 
 	@Override
-	public void setIngredients(RollingRecipe recipe, IIngredients ingredients) {
-		ingredients.setInputIngredients(recipe.getIngredients());
-		ArrayList<ItemStack> stacks = new ArrayList<>();
-		stacks.add(recipe.getResultItem());
-		ingredients.setOutputs(VanillaTypes.ITEM, stacks);
-	}
+	public void setRecipe(IRecipeLayoutBuilder builder, RollingRecipe recipe, IFocusGroup focuses) {
+		builder
+				.addSlot(RecipeIngredientRole.INPUT, 15, 9)
+				.setBackground(getRenderedSlot(), -1, -1)
+				.addIngredients(recipe.getIngredient());
 
-	@Override
-	public void setRecipe(IRecipeLayout recipeLayout, RollingRecipe recipe, IIngredients ingredients) {
-		IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-		itemStacks.init(0, true, 14, 8);
-		itemStacks.set(0, Arrays.asList(recipe.getIngredient().getItems()));
-
-		ItemStack result = recipe.getResultItem();
-		int yOffset = (0 / 2) * -19;
-
-		itemStacks.init(1, false, 139, 27 + yOffset);
-		itemStacks.set(1, result);
-
-		//addStochasticTooltip(itemStacks, results);
+		builder
+				.addSlot(RecipeIngredientRole.OUTPUT, 140, 28)
+				.setBackground(getRenderedSlot(), -1, -1)
+				.addItemStack(recipe.getResultItem());
 	}
 
 	@Override
 	public void draw(RollingRecipe recipe, PoseStack matrixStack, double mouseX, double mouseY) {
-		AllGuiTextures.JEI_SLOT.render(matrixStack, 14, 8);
 		AllGuiTextures.JEI_ARROW.render(matrixStack, 85, 32);
 		AllGuiTextures.JEI_DOWN_ARROW.render(matrixStack, 43, 4);
 		rolling_mill.draw(matrixStack, 48, 27);
-
-		getRenderedSlot(recipe, 0).render(matrixStack, 139, 27);
 	}
 }

--- a/src/main/java/com/mrh0/createaddition/index/CASpriteShifts.java
+++ b/src/main/java/com/mrh0/createaddition/index/CASpriteShifts.java
@@ -5,7 +5,7 @@ import com.simibubi.create.foundation.block.connected.CTSpriteShiftEntry;
 import net.minecraft.resources.ResourceLocation;
 
 import static com.simibubi.create.foundation.block.connected.CTSpriteShifter.getCT;
-import static com.simibubi.create.foundation.block.connected.CTSpriteShifter.CTType.OMNIDIRECTIONAL;
+import static com.simibubi.create.foundation.block.connected.AllCTTypes.OMNIDIRECTIONAL;
 
 import com.mrh0.createaddition.CreateAddition;
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[39,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[40,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="MIT License, Copyright 2022 MRH0"
@@ -52,7 +52,7 @@ Join the Discord: https://discord.gg/mRbNnyKTEu
 [[dependencies.createaddition]]
     modId="create"
     mandatory=true
-    versionRange="[mc1.18.1_v0.4.1,)"
+    versionRange="[0.5,0.6)"
     ordering="NONE"
     side="BOTH"
 [[dependencies.createaddition]]


### PR DESCRIPTION
- Removed references to Furnace Engine
- Renamed Lang.translate calls to Lang.translateDirect
- Update JEI compat to match Create's implementation
- Simple migration from CTSpriteShifter.CTType to AllCTTypes
- Update mods.toml
- Update build.gradle

**Note**: Was initially able to build this at first and was able to use runClient in IntellJ, then I ran into a NullPointerException during testing. Something to do with the Electric Motor and unable to get the Kinetic data from the Create side. After that, I was looking into the issue and in the mean time ran runData, which failed. Ever since that failure I was unable to rebuild the project or run the project without receiving an error similar to the following:

`Entry data/minecraft/tags/fluids/water.json is a duplicate but no duplicate handling strategy has been set`

I've already tried deleting all of the caches on my machine in the .gradle file and deleted the build folder in the project several of times to no avail. So unfortunately, this PR is not fully tested and the issue I ran into hasn't been fully resolved. Hopefully, the changes committed here will help you save on some development time though.

**Edit**: Ha, seems like I could get it to build outside of IntelliJ though, _great_.
**Edit 2**: Figured out the issue regarding the Electric Motor, seems like it is an issue on Create's side: https://github.com/Creators-of-Create/Create/issues/3186. A quick "fix" to the issue is to just register Create's IStressValueProvider as Create Addition's provider, like so:
```
    private void setup(final FMLCommonSetupEvent event) {
    	CAPotatoCannonProjectiles.register();
        BlockStressValues.registerProvider(MODID, AllConfigs.SERVER.kinetics.stressValues);
    }
```
Of course, the ideal solution would be that Create Addition implements their own IStressValueProvider though.