### PR TITLE
Added Sequenced Assemby compatibility for the Rolling Mill

### DIFF
--- a/src/main/java/com/mrh0/createaddition/blocks/rolling_mill/RollingMillTileEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/rolling_mill/RollingMillTileEntity.java
@@ -3,15 +3,11 @@ package com.mrh0.createaddition.blocks.rolling_mill;
 import java.util.List;
 import java.util.Optional;
 
-import com.mrh0.createaddition.CreateAddition;
 import com.mrh0.createaddition.config.Config;
 import com.mrh0.createaddition.recipe.rolling.RollingRecipe;
 import com.mrh0.createaddition.recipe.rolling.RollingRecipeType;
-import com.simibubi.create.AllRecipeTypes;
 import com.simibubi.create.content.contraptions.base.KineticTileEntity;
 import com.simibubi.create.content.contraptions.itemAssembly.SequencedAssemblyRecipe;
-import com.simibubi.create.content.contraptions.itemAssembly.SequencedAssemblyRecipeSerializer;
-import com.simibubi.create.content.contraptions.processing.ProcessingRecipe;
 import com.simibubi.create.foundation.tileEntity.TileEntityBehaviour;
 import com.simibubi.create.foundation.tileEntity.behaviour.belt.DirectBeltInputBehaviour;
 import com.simibubi.create.foundation.utility.VecHelper;

--- a/src/main/java/com/mrh0/createaddition/blocks/rolling_mill/RollingMillTileEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/rolling_mill/RollingMillTileEntity.java
@@ -1,15 +1,25 @@
 package com.mrh0.createaddition.blocks.rolling_mill;
 
+import java.util.List;
 import java.util.Optional;
 
+import com.mrh0.createaddition.CreateAddition;
 import com.mrh0.createaddition.config.Config;
 import com.mrh0.createaddition.recipe.rolling.RollingRecipe;
+import com.mrh0.createaddition.recipe.rolling.RollingRecipeType;
+import com.simibubi.create.AllRecipeTypes;
 import com.simibubi.create.content.contraptions.base.KineticTileEntity;
+import com.simibubi.create.content.contraptions.itemAssembly.SequencedAssemblyRecipe;
+import com.simibubi.create.content.contraptions.itemAssembly.SequencedAssemblyRecipeSerializer;
+import com.simibubi.create.content.contraptions.processing.ProcessingRecipe;
+import com.simibubi.create.foundation.tileEntity.TileEntityBehaviour;
+import com.simibubi.create.foundation.tileEntity.behaviour.belt.DirectBeltInputBehaviour;
 import com.simibubi.create.foundation.utility.VecHelper;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
+import net.minecraft.core.Vec3i;
 import net.minecraft.core.particles.ItemParticleOption;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
@@ -47,6 +57,12 @@ public class RollingMillTileEntity extends KineticTileEntity {
 	}
 
 	@Override
+	public void addBehaviours(List<TileEntityBehaviour> behaviours) {
+		super.addBehaviours(behaviours);
+		behaviours.add(new DirectBeltInputBehaviour(this));
+	}
+
+	@Override
 	public void tick() {
 		super.tick();
 
@@ -68,6 +84,49 @@ public class RollingMillTileEntity extends KineticTileEntity {
 				process();
 			return;
 		}
+
+		//Note: this code below is taken and adapted from the Create repo, specifically:
+		//https://github.com/Creators-of-Create/Create/blob/a92855254c9a7b85ba28781e2e3ce7169549cbf7/src/main/java/com/simibubi/create/content/contraptions/components/saw/SawTileEntity.java#L190,
+		var ejectDirection = getEjectDirection();
+		for (int slot = 0; slot < outputInv.getSlots(); slot++) {
+			var stack = outputInv.getStackInSlot(slot);
+			if(stack.isEmpty())
+				continue;
+			ItemStack tryExport = getBehaviour(DirectBeltInputBehaviour.TYPE).tryExportingToBeltFunnel(stack,ejectDirection,false);
+			if(tryExport != null) {
+				if(tryExport.getCount() != stack.getCount()) {
+					outputInv.setStackInSlot(slot,tryExport);
+					setChanged();
+					sendData();
+				}
+			}
+		}
+
+		var step = new Vec3i(ejectDirection.getStepX(),ejectDirection.getStepY(),ejectDirection.getStepZ());
+		BlockPos nextPos = getBlockPos().offset(step);
+		DirectBeltInputBehaviour behaviour = TileEntityBehaviour.get(level,nextPos,DirectBeltInputBehaviour.TYPE);
+		if(behaviour != null) {
+			boolean changed = false;
+			if(!behaviour.canInsertFromSide(ejectDirection))
+				return;
+			if(level.isClientSide && !isVirtual())
+				return;
+			for (int slot = 0; slot < outputInv.getSlots(); slot++) {
+				var stack = outputInv.getStackInSlot(slot);
+				if(stack.isEmpty())
+					continue;
+				ItemStack rest = behaviour.handleInsertion(stack,ejectDirection,false);
+				if(rest.equals(stack,false))
+					continue;
+				outputInv.setStackInSlot(slot,rest);
+				changed = true;
+			}
+			if(changed) {
+				setChanged();
+				sendData();
+			}
+		}
+		//end of copied code
 
 		if (inputInv.getStackInSlot(0)
 			.isEmpty())
@@ -91,6 +150,23 @@ public class RollingMillTileEntity extends KineticTileEntity {
 		sendData();
 	}
 
+	private Direction getEjectDirection() {
+		var block = ((RollingMillBlock) getBlockState().getBlock());
+		var speed = getSpeed();
+		block.getRotationAxis(getBlockState());
+		boolean rotation = speed >= 0;
+		Direction ejectDirection = Direction.UP;
+		switch (block.getRotationAxis(getBlockState())) {
+			case X -> {
+				ejectDirection = rotation ? Direction.SOUTH : Direction.NORTH;
+			}
+			case Z -> {
+				ejectDirection = rotation ? Direction.WEST : Direction.EAST;
+			}
+		}
+		return ejectDirection;
+	}
+
 	@Override
 	public void setRemoved() {
 		super.setRemoved();
@@ -99,6 +175,22 @@ public class RollingMillTileEntity extends KineticTileEntity {
 	
 	private void process() {
 		RecipeWrapper inventoryIn = new RecipeWrapper(inputInv);
+
+		var sequenced = SequencedAssemblyRecipe.getRecipe(level,inventoryIn.getItem(0), RollingRecipe.TYPE,RollingRecipe.class);
+		if(sequenced.isPresent()) {
+			var recipe = sequenced.get();
+			var results = recipe.rollResults();
+			if(!results.isEmpty()) {
+				var result = results.get(0);
+				ItemHandlerHelper.insertItemStacked(outputInv, result, false);
+				ItemStack stackInSlot = inputInv.getStackInSlot(0);
+				stackInSlot.shrink(1);
+				inputInv.setStackInSlot(0, stackInSlot);
+				sendData();
+				setChanged();
+				return;
+			}
+		}
 
 		if (lastRecipe == null || !lastRecipe.matches(inventoryIn, level)) {
 			Optional<RollingRecipe> recipe = find(inventoryIn, level);
@@ -164,6 +256,11 @@ public class RollingMillTileEntity extends KineticTileEntity {
 		tester.setStackInSlot(0, stack);
 		RecipeWrapper inventoryIn = new RecipeWrapper(tester);
 
+		var sequenced = SequencedAssemblyRecipe.getRecipe(level,stack,RollingRecipe.TYPE,RollingRecipe.class);
+		if(sequenced.isPresent()) {
+			return true;
+		}
+
 		if (lastRecipe != null && lastRecipe.matches(inventoryIn, level))
 			return true;
 		return find(inventoryIn, level)
@@ -200,8 +297,11 @@ public class RollingMillTileEntity extends KineticTileEntity {
 		}
 
 	}
-
 	public Optional<RollingRecipe> find(RecipeWrapper inv, Level world) {
+		var sequenced = SequencedAssemblyRecipe.getRecipe(level,inv.getItem(0), new RollingRecipeType(),RollingRecipe.class);
+		if(sequenced.isPresent()) {
+			return sequenced;
+		}
 		return world.getRecipeManager().getRecipeFor(RollingRecipe.TYPE, inv, world);
 	}
 	

--- a/src/main/java/com/mrh0/createaddition/compat/jei/AnimatedRollingMill.java
+++ b/src/main/java/com/mrh0/createaddition/compat/jei/AnimatedRollingMill.java
@@ -8,11 +8,22 @@ import com.simibubi.create.foundation.gui.element.GuiGameElement;
 
 public class AnimatedRollingMill extends AnimatedKinetics {
 
+	private boolean shadow = true;
+
+	public AnimatedRollingMill(boolean shadow) {
+		this.shadow = shadow;
+	}
+
+	public AnimatedRollingMill() {
+		shadow = true;
+	}
+
 	@Override
 	public void draw(PoseStack matrixStack, int xOffset, int yOffset) {
 		matrixStack.pushPose();
 		matrixStack.translate(xOffset, yOffset, 0);
-		AllGuiTextures.JEI_SHADOW.render(matrixStack, -16, 13);
+		if(shadow)
+			AllGuiTextures.JEI_SHADOW.render(matrixStack, -16, 13);
 		matrixStack.translate(-2, 18, 0);
 		int scale = 22;
 

--- a/src/main/java/com/mrh0/createaddition/compat/jei/RollingMillAssemblySubCategory.java
+++ b/src/main/java/com/mrh0/createaddition/compat/jei/RollingMillAssemblySubCategory.java
@@ -1,15 +1,14 @@
-package com.mrh0.createaddition.recipe.rolling;
+package com.mrh0.createaddition.compat.jei;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mrh0.createaddition.compat.jei.AnimatedRollingMill;
 import com.simibubi.create.compat.jei.category.sequencedAssembly.SequencedAssemblySubCategory;
 import com.simibubi.create.content.contraptions.itemAssembly.SequencedRecipe;
 
-public class RollingSubCategory extends SequencedAssemblySubCategory {
+public class RollingMillAssemblySubCategory extends SequencedAssemblySubCategory {
 
     AnimatedRollingMill mill;
 
-    public RollingSubCategory() {
+    public RollingMillAssemblySubCategory() {
         super(20);
         mill = new AnimatedRollingMill(false);
     }

--- a/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingMillRecipeParams.java
+++ b/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingMillRecipeParams.java
@@ -1,0 +1,35 @@
+package com.mrh0.createaddition.recipe.rolling;
+
+import com.mrh0.createaddition.config.Config;
+import com.simibubi.create.content.contraptions.processing.HeatCondition;
+import com.simibubi.create.content.contraptions.processing.ProcessingOutput;
+import com.simibubi.create.content.contraptions.processing.ProcessingRecipeBuilder;
+import net.minecraft.core.NonNullList;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.Ingredient;
+
+public class RollingMillRecipeParams extends ProcessingRecipeBuilder.ProcessingRecipeParams {
+
+    protected RollingMillRecipeParams(ResourceLocation id, Ingredient input, ProcessingOutput output) {
+        super(id);
+        if(ingredients == null) {
+            ingredients =  NonNullList.create();
+        }
+        ingredients.add(input);
+        if(results == null) {
+            results = NonNullList.create();
+        }
+        results.add(output);
+        if(fluidIngredients == null) {
+            fluidIngredients = NonNullList.create();
+        }
+        fluidIngredients.clear();
+        if(fluidResults == null) {
+            fluidResults = NonNullList.create();
+        }
+        fluidResults.clear();
+        processingDuration = Config.ROLLING_MILL_PROCESSING_DURATION.get();
+        requiredHeat = HeatCondition.NONE;
+        keepHeldItem = false;
+    }
+}

--- a/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingRecipe.java
+++ b/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingRecipe.java
@@ -2,22 +2,19 @@ package com.mrh0.createaddition.recipe.rolling;
 
 import com.mrh0.createaddition.CreateAddition;
 
+import com.mrh0.createaddition.compat.jei.RollingMillAssemblySubCategory;
 import com.mrh0.createaddition.index.CABlocks;
 import com.simibubi.create.compat.jei.category.sequencedAssembly.SequencedAssemblySubCategory;
 import com.simibubi.create.content.contraptions.itemAssembly.IAssemblyRecipe;
 import com.simibubi.create.content.contraptions.processing.ProcessingOutput;
 import com.simibubi.create.content.contraptions.processing.ProcessingRecipe;
-import com.simibubi.create.content.contraptions.processing.ProcessingRecipeBuilder;
-import com.simibubi.create.foundation.utility.recipe.IRecipeTypeInfo;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.Registry;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
-import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.ItemLike;
@@ -39,7 +36,7 @@ public class RollingRecipe extends ProcessingRecipe<RecipeWrapper> implements IA
 	public static RecipeSerializer<?> SERIALIZER = Registry.RECIPE_SERIALIZER.get(new ResourceLocation(CreateAddition.MODID, "rolling"));
 
 	protected RollingRecipe(Ingredient ingredient, ItemStack output, ResourceLocation id) {
-		super(new RollingRecipeInfo(id,SERIALIZER,TYPE),new RollingMillRecipeParams(id,ingredient,new ProcessingOutput(output,1f)));
+		super(new RollingRecipeInfo(id, (RollingRecipeSerializer) SERIALIZER,TYPE),new RollingMillRecipeParams(id,ingredient,new ProcessingOutput(output,1f)));
 		this.output = output;
 		this.id = id;
 		this.ingredient = ingredient;
@@ -126,6 +123,6 @@ public class RollingRecipe extends ProcessingRecipe<RecipeWrapper> implements IA
 
 	@Override
 	public Supplier<Supplier<SequencedAssemblySubCategory>> getJEISubCategory() {
-		return () -> RollingSubCategory::new;
+		return () -> RollingMillAssemblySubCategory::new;
 	}
 }

--- a/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingRecipe.java
+++ b/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingRecipe.java
@@ -13,6 +13,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.core.Registry;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -110,7 +111,7 @@ public class RollingRecipe extends ProcessingRecipe<RecipeWrapper> implements IA
 
 	@Override
 	public Component getDescriptionForAssembly() {
-		return new TextComponent("Rolling in Mill").withStyle(ChatFormatting.DARK_GREEN);
+		return new TranslatableComponent("createaddition.recipe.rolling.sequence").withStyle(ChatFormatting.DARK_GREEN);
 	}
 
 	@Override

--- a/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingRecipe.java
+++ b/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingRecipe.java
@@ -2,17 +2,32 @@ package com.mrh0.createaddition.recipe.rolling;
 
 import com.mrh0.createaddition.CreateAddition;
 
+import com.mrh0.createaddition.index.CABlocks;
+import com.simibubi.create.compat.jei.category.sequencedAssembly.SequencedAssemblySubCategory;
+import com.simibubi.create.content.contraptions.itemAssembly.IAssemblyRecipe;
+import com.simibubi.create.content.contraptions.processing.ProcessingOutput;
+import com.simibubi.create.content.contraptions.processing.ProcessingRecipe;
+import com.simibubi.create.content.contraptions.processing.ProcessingRecipeBuilder;
+import com.simibubi.create.foundation.utility.recipe.IRecipeTypeInfo;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.Registry;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.items.wrapper.RecipeWrapper;
 
-public class RollingRecipe implements Recipe<RecipeWrapper> {
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class RollingRecipe extends ProcessingRecipe<RecipeWrapper> implements IAssemblyRecipe {
 
 	protected final ItemStack output;
 	protected final ResourceLocation id;
@@ -23,6 +38,7 @@ public class RollingRecipe implements Recipe<RecipeWrapper> {
 	public static RecipeSerializer<?> SERIALIZER = Registry.RECIPE_SERIALIZER.get(new ResourceLocation(CreateAddition.MODID, "rolling"));
 
 	protected RollingRecipe(Ingredient ingredient, ItemStack output, ResourceLocation id) {
+		super(new RollingRecipeInfo(id,SERIALIZER,TYPE),new RollingMillRecipeParams(id,ingredient,new ProcessingOutput(output,1f)));
 		this.output = output;
 		this.id = id;
 		this.ingredient = ingredient;
@@ -37,6 +53,16 @@ public class RollingRecipe implements Recipe<RecipeWrapper> {
 		if (inv.isEmpty())
 			return false;
 		return ingredient.test(inv.getItem(0));
+	}
+
+	@Override
+	protected int getMaxInputCount() {
+		return 1;
+	}
+
+	@Override
+	protected int getMaxOutputCount() {
+		return 100;
 	}
 
 	@Override
@@ -81,4 +107,24 @@ public class RollingRecipe implements Recipe<RecipeWrapper> {
 	}
 	
 	public static void register() {};
+
+	@Override
+	public Component getDescriptionForAssembly() {
+		return new TextComponent("Rolling in Mill").withStyle(ChatFormatting.DARK_GREEN);
+	}
+
+	@Override
+	public void addRequiredMachines(Set<ItemLike> set) {
+		set.add(CABlocks.ROLLING_MILL.get());
+	}
+
+	@Override
+	public void addAssemblyIngredients(List<Ingredient> list) {
+
+	}
+
+	@Override
+	public Supplier<Supplier<SequencedAssemblySubCategory>> getJEISubCategory() {
+		return () -> RollingSubCategory::new;
+	}
 }

--- a/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingRecipeInfo.java
+++ b/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingRecipeInfo.java
@@ -1,0 +1,34 @@
+package com.mrh0.createaddition.recipe.rolling;
+
+import com.simibubi.create.foundation.utility.recipe.IRecipeTypeInfo;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.RecipeType;
+
+public class RollingRecipeInfo implements IRecipeTypeInfo {
+
+    private ResourceLocation id;
+    private RecipeSerializer<?> serializer;
+    private RecipeType<RollingRecipe> type;
+
+    public RollingRecipeInfo(ResourceLocation id, RecipeSerializer<?> serializer, RecipeType<RollingRecipe> type) {
+        this.id = id;
+        this.serializer = serializer;
+        this.type = type;
+    }
+
+    @Override
+    public ResourceLocation getId() {
+        return id;
+    }
+
+    @Override
+    public <T extends RecipeSerializer<?>> T getSerializer() {
+        return null;
+    }
+
+    @Override
+    public <T extends RecipeType<?>> T getType() {
+        return null;
+    }
+}

--- a/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingRecipeInfo.java
+++ b/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingRecipeInfo.java
@@ -8,10 +8,10 @@ import net.minecraft.world.item.crafting.RecipeType;
 public class RollingRecipeInfo implements IRecipeTypeInfo {
 
     private ResourceLocation id;
-    private RecipeSerializer<?> serializer;
+    private RollingRecipeSerializer serializer;
     private RecipeType<RollingRecipe> type;
 
-    public RollingRecipeInfo(ResourceLocation id, RecipeSerializer<?> serializer, RecipeType<RollingRecipe> type) {
+    public RollingRecipeInfo(ResourceLocation id, RollingRecipeSerializer serializer, RecipeType<RollingRecipe> type) {
         this.id = id;
         this.serializer = serializer;
         this.type = type;
@@ -24,11 +24,11 @@ public class RollingRecipeInfo implements IRecipeTypeInfo {
 
     @Override
     public <T extends RecipeSerializer<?>> T getSerializer() {
-        return null;
+        return (T) serializer;
     }
 
     @Override
     public <T extends RecipeType<?>> T getType() {
-        return null;
+        return (T) type;
     }
 }

--- a/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingSubCategory.java
+++ b/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingSubCategory.java
@@ -11,7 +11,7 @@ public class RollingSubCategory extends SequencedAssemblySubCategory {
 
     public RollingSubCategory() {
         super(20);
-        mill = new AnimatedRollingMill();
+        mill = new AnimatedRollingMill(false);
     }
 
     @Override

--- a/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingSubCategory.java
+++ b/src/main/java/com/mrh0/createaddition/recipe/rolling/RollingSubCategory.java
@@ -1,0 +1,25 @@
+package com.mrh0.createaddition.recipe.rolling;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mrh0.createaddition.compat.jei.AnimatedRollingMill;
+import com.simibubi.create.compat.jei.category.sequencedAssembly.SequencedAssemblySubCategory;
+import com.simibubi.create.content.contraptions.itemAssembly.SequencedRecipe;
+
+public class RollingSubCategory extends SequencedAssemblySubCategory {
+
+    AnimatedRollingMill mill;
+
+    public RollingSubCategory() {
+        super(20);
+        mill = new AnimatedRollingMill();
+    }
+
+    @Override
+    public void draw(SequencedRecipe<?> sequencedRecipe, PoseStack ms, double mouseX, double mouseY, int index) {
+        ms.pushPose();
+        ms.translate(0, 51.5f, 0);
+        ms.scale(.6f, .6f, .6f);
+        mill.draw(ms, getWidth() / 2, 30);
+        ms.popPose();
+    }
+}

--- a/src/main/resources/assets/createaddition/lang/de_de.json
+++ b/src/main/resources/assets/createaddition/lang/de_de.json
@@ -3,6 +3,7 @@
 	"createaddition.tooltip.energy.consumption": "Energie Nutzung:",
 	"createaddition.tooltip.energy.production": "Energie Generiert:",
 	"createaddition.recipe.rolling": "Walzen",
+	"createaddition.recipe.rolling.sequence": "Walzen in der Walze",
 	
 	"desc.immersiveengineering.info.mineral.sphalerite": "Sphalerit",
 	

--- a/src/main/resources/assets/createaddition/lang/en_us.json
+++ b/src/main/resources/assets/createaddition/lang/en_us.json
@@ -15,6 +15,7 @@
 	"createaddition.tooltip.connector.info": "Connector Info:",
 	
 	"createaddition.recipe.rolling": "Rolling",
+	"createaddition.recipe.rolling.sequence": "Rolling in Mill",
 	"createaddition.recipe.charging": "Charging",
 	
 	"desc.immersiveengineering.info.mineral.sphalerite": "Sphalerite",


### PR DESCRIPTION
This makes it possible to use the Rolling Mill in Sequenced Assembly, useful for Modpack creators.


Of Note: this adds to the behavior of the Rolling Mill, making it serviceable via belts from both sides, on the height of the belt. This does not invalidate the old behavior. This has the added benefit of making automation of the Rolling Mill easier.
![rolling_mill](https://user-images.githubusercontent.com/20888711/183727811-6abcdd60-5711-4b3c-9a92-d34dd5cd84c7.png)


Supplementary Changes:

- Adds a new translation key: "createaddition.recipe.rolling.sequence" for the text displayed in JEI
- Adds JEI display for the Rolling Mill when used in Sequenced Assembly

