### PR TITLE
fix: gradle runClient/runServer not working due to dependency conflict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,7 +189,7 @@ dependencies {
         jarJar.pin(it, project.registrate_version)
     }
 
-    implementation fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
+    compileOnly fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
 
     compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}:api")
     runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}")


### PR DESCRIPTION
fixes #325 