### PR TITLE
fix: rolling mill does not work if funnel is placed to output side

### DIFF
--- a/src/main/java/com/mrh0/createaddition/blocks/rolling_mill/RollingMillTileEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/rolling_mill/RollingMillTileEntity.java
@@ -103,8 +103,6 @@ public class RollingMillTileEntity extends KineticTileEntity {
 		DirectBeltInputBehaviour behaviour = TileEntityBehaviour.get(level,nextPos,DirectBeltInputBehaviour.TYPE);
 		if(behaviour != null) {
 			boolean changed = false;
-			if(!behaviour.canInsertFromSide(ejectDirection))
-				return;
 			if(level.isClientSide && !isVirtual())
 				return;
 			for (int slot = 0; slot < outputInv.getSlots(); slot++) {


### PR DESCRIPTION
The problem was in the copied chunk of code. It was adopted from sawmill tile entity which checked if the output side is blocked and did not process meterials if so. Removing this condition fixes the problem.
Fixes #324