### PR TITLE
[FABRIC] Updated to 0.5d patch 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,17 +61,30 @@ dependencies {
     mappings loom.officialMojangMappings()
 
     modImplementation("net.fabricmc:fabric-loader:${project.loader_version}")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:${project.fabric_version}")
 
     modCompileOnly("me.shedaniel:RoughlyEnoughItems-api-fabric:${project.rei_version}") { transitive = false }
     modImplementation("me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}") { transitive = false }
     modImplementation("dev.architectury:architectury-fabric:${project.architectury_version}")
-    modImplementation("dev.onyxstudios.cardinal-components-api:cardinal-components-base:3.3.1")
-    modImplementation("com.simibubi:Create:${project.create_version}")
+    modImplementation("dev.onyxstudios.cardinal-components-api:cardinal-components-base:4.2.0")
     modImplementation("curse.maven:cc-restitched-462672:3723736")
     modImplementation("curse.maven:applied-energistics-2-223794:3735901")
     modApi("me.shedaniel.cloth:cloth-config-fabric:6.2.62") {
         exclude(group: "net.fabricmc.fabric-api")
     }
+    
+    //General create dependencies and setup
+    modImplementation("com.simibubi.create:create-fabric-${project.minecraft_version}:${project.create_version}") { transitive = false }
+	modImplementation("io.github.fabricators_of_create:Porting-Lib:${project.port_lib_version}+${project.minecraft_version}-dev.${project.port_lib_hash}")
+	modImplementation("me.alphamode:ForgeTags:${project.forge_tags_version}")
+	modImplementation("com.electronwill.night-config:core:${project.night_config_core_version}")
+	modImplementation("com.electronwill.night-config:toml:${project.night_config_toml_version}")
+	modImplementation("curse.maven:forge-config-api-port-fabric-547434:${project.config_api_id}") { transitive = false }
+	modImplementation("com.tterrag.registrate:Registrate:${project.registrate_version}")
+	modImplementation("com.jozufozu.flywheel:flywheel-fabric-${flywheel_minecraft_version}:${project.flywheel_version}")
+	modImplementation("com.jamieswhiteshirt:reach-entity-attributes:${project.reach_entity_attributes_version}")
+	modImplementation("io.github.tropheusj:milk-lib:${project.milk_lib_version}")
+	implementation("com.google.code.findbugs:jsr305:${project.jsr305_version}")
 
     include modApi('teamreborn:energy:2.2.0') {
         exclude(group: "net.fabricmc.fabric-api")

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,11 +13,22 @@ mixin_version = 0.8.5
 librarian_version = 1.+
 shadow_version = 7.1.0
 cursegradle_version = 1.4.0
-parchment_version = BLEEDING-20220313.132143-1@zip
-
-create_version = 0.5.0c-704
+parchment_version = 2022.07.17
+config_api_id = 3671141
+forge_config_api_port_version = 3.2.0
+fake_player_api_version = 0.3.0
+flywheel_minecraft_version = 1.18.2
+flywheel_version = 0.6.4-30
+reach_entity_attributes_version = 2.1.1
 registrate_version = MC1.18.2-1.1.3
-flywheel_version = 1.18-0.6.4.30
+forge_tags_version = 2.1
+milk_lib_version = 0.3.2
+port_lib_version = 1.2.421-beta
+port_lib_hash = b8d195a
+night_config_core_version = 3.6.3
+night_config_toml_version = 3.6.3
+jsr305_version = 3.0.2
+create_version = 0.5.0d-731
 # https://www.curseforge.com/minecraft/mc-mods/roughly-enough-items/files
 rei_version = 8.3.519
 # https://www.curseforge.com/minecraft/mc-mods/forge-config-api-port-fabric/files


### PR DESCRIPTION
Updated gradle dependencies to make the mod compile and run with the newest version of fabric create (0.5d patch 2). Testing also shows this fixes issues #333 and #329. The gradle dependencies are just grabbed from the [create fabric addon template](https://github.com/Fabricators-of-Create/create-fabric-addon-template/blob/1.18/build.gradle) and this seemed to fix everything.