### PR TITLE
Fixed chunks losing their light.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,6 +195,7 @@ dependencies {
     runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}")
     runtimeOnly fg.deobf("curse.maven:immersive-engineering-231951:3964014")
     runtimeOnly fg.deobf("curse.maven:immersive-petroleum-268250:4314934")
+    //runtimeOnly fg.deobf("curse.maven:radon-596879:3707321")
 
     implementation fg.deobf("curse.maven:create-328085:4174329")
     implementation fg.deobf("curse.maven:flywheel-486392:4174748")

--- a/src/main/java/com/mrh0/createaddition/energy/BaseElectricTileEntity.java
+++ b/src/main/java/com/mrh0/createaddition/energy/BaseElectricTileEntity.java
@@ -105,12 +105,18 @@ public abstract class BaseElectricTileEntity extends SmartTileEntity {
 	public void updateCache(Direction side) {
 		if(updateBlocked > 10) return;
 		updateBlocked++;
+		if (!level.isLoaded(worldPosition.relative(side))) {
+			setCache(side, LazyOptional.empty());
+			return;
+		}
 		BlockEntity te = level.getBlockEntity(worldPosition.relative(side));
 		if(te == null) {
 			setCache(side, LazyOptional.empty());
 			return;
 		}
 		LazyOptional<IEnergyStorage> le = te.getCapability(CapabilityEnergy.ENERGY, side.getOpposite());
+		// Make sure the side isn't already cached.
+		if (le.equals(getCachedEnergy(side))) return;
 		setCache(side, le);
 		le.addListener((es) -> updateCache(side));
 	}


### PR DESCRIPTION
Fixed two issues, the first one is the one where chunks loses their light date due to being loaded while unloading.

The second issue that I "fixed" is that every call to updateCache(Direction) would add a new listener to the LazyOptional, meaning you could update the block, the updateCache() method would be called, that would call updateCache(Direction) for every side and add a new listener for each side with a tileentity.

The second issue isn't really fixed, but mitigated, for example:
A1 = Accumulator 1 (0, 0, 0)
A2 = Accumulator 2 (1, 0, 0)
You can still add duplicate entries to the LazyOptional by breaking and placing A1, as the listeners are only called if A2 is destroyed / unloaded - I didn't really find a good way to solve this issue without replacing the LazyOptinal with something else, as you can't remove a listener that is already registered.