### PR TITLE
Accumulators should send block updates.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,6 +195,7 @@ dependencies {
     runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}")
     runtimeOnly fg.deobf("curse.maven:immersive-engineering-231951:3964014")
     runtimeOnly fg.deobf("curse.maven:immersive-petroleum-268250:4314934")
+    //runtimeOnly fg.deobf("curse.maven:mekanism-268560:3875976")
     //runtimeOnly fg.deobf("curse.maven:radon-596879:3707321")
 
     implementation fg.deobf("curse.maven:create-328085:4174329")

--- a/src/main/java/com/mrh0/createaddition/blocks/modular_accumulator/ModularAccumulatorTileEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/modular_accumulator/ModularAccumulatorTileEntity.java
@@ -6,7 +6,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.mrh0.createaddition.CreateAddition;
+import com.mrh0.createaddition.blocks.connector.ConnectorBlock;
 import com.mrh0.createaddition.config.Config;
+import com.mrh0.createaddition.debug.IDebugDrawer;
 import com.mrh0.createaddition.energy.IMultiTileEnergyContainer;
 import com.mrh0.createaddition.energy.InternalEnergyStorage;
 import com.mrh0.createaddition.network.EnergyNetworkPacket;
@@ -14,6 +16,7 @@ import com.mrh0.createaddition.network.IObserveTileEntity;
 import com.mrh0.createaddition.network.ObservePacket;
 import com.mrh0.createaddition.util.Util;
 import com.simibubi.create.Create;
+import com.simibubi.create.CreateClient;
 import com.simibubi.create.content.contraptions.goggles.IHaveGoggleInformation;
 import com.simibubi.create.foundation.advancement.AllAdvancements;
 import com.simibubi.create.foundation.tileEntity.SmartTileEntity;
@@ -30,17 +33,19 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.fluids.IFluidTank;
 
-public class ModularAccumulatorTileEntity extends SmartTileEntity implements IHaveGoggleInformation, IMultiTileEnergyContainer, IObserveTileEntity {
+public class ModularAccumulatorTileEntity extends SmartTileEntity implements IHaveGoggleInformation, IMultiTileEnergyContainer, IObserveTileEntity, IDebugDrawer {
 
 	public static final int CAPACITY = Config.ACCUMULATOR_CAPACITY.get(),
 			MAX_IN = Config.ACCUMULATOR_MAX_INPUT.get(),
@@ -477,7 +482,7 @@ public class ModularAccumulatorTileEntity extends SmartTileEntity implements IHa
 		if (ModularAccumulatorBlock.isAccumulator(state)) { // safety
 			state = state.setValue(ModularAccumulatorBlock.BOTTOM, getController().getY() == getBlockPos().getY());
 			state = state.setValue(ModularAccumulatorBlock.TOP, getController().getY() + height - 1 == getBlockPos().getY());
-			level.setBlock(getBlockPos(), state, 6);
+			level.setBlock(getBlockPos(), state, Block.UPDATE_NEIGHBORS | Block.UPDATE_CLIENTS | Block.UPDATE_INVISIBLE);
 		}
 		setChanged();
 		// When the multi block is updated, the neighborChanged method isn't fired,
@@ -572,5 +577,15 @@ public class ModularAccumulatorTileEntity extends SmartTileEntity implements IHa
 
 	public InternalEnergyStorage getEnergy(int accumulator) {
 		return energyStorage;
+	}
+
+	@Override
+	public void drawDebug() {
+		if (level == null) return;
+		ModularAccumulatorTileEntity controller = getControllerTE();
+		if (controller == null) return;
+		// Outline controller.
+		VoxelShape shape = level.getBlockState(controller.getBlockPos()).getBlockSupportShape(level, controller.getBlockPos());
+		CreateClient.OUTLINER.chaseAABB("ca_accumulator", shape.bounds().move(controller.getBlockPos())).lineWidth(0.0625F).colored(0xFF5B5B);
 	}
 }

--- a/src/main/java/com/mrh0/createaddition/debug/AdditionDebugger.java
+++ b/src/main/java/com/mrh0/createaddition/debug/AdditionDebugger.java
@@ -1,0 +1,34 @@
+package com.mrh0.createaddition.debug;
+
+import com.simibubi.create.content.contraptions.KineticDebugger;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+
+/**
+ * Basically a copy of creates {@link KineticDebugger}, but for create addition blocks.
+ */
+public class AdditionDebugger {
+
+	public AdditionDebugger() {}
+
+	public static void tick() {
+		if (!Minecraft.getInstance().options.renderDebug) return;
+		IDebugDrawer drawer = getSelected();
+		if (drawer == null) return;
+		drawer.drawDebug();
+	}
+
+	public static IDebugDrawer getSelected() {
+		HitResult result = Minecraft.getInstance().hitResult;
+		ClientLevel world = Minecraft.getInstance().level;
+		if (result == null || world == null) return null;
+		if (!(result instanceof BlockHitResult res)) return null;
+		BlockEntity entity = world.getBlockEntity(res.getBlockPos());
+		if (entity instanceof IDebugDrawer drawer) return drawer;
+		return null;
+	}
+
+}

--- a/src/main/java/com/mrh0/createaddition/debug/IDebugDrawer.java
+++ b/src/main/java/com/mrh0/createaddition/debug/IDebugDrawer.java
@@ -1,0 +1,7 @@
+package com.mrh0.createaddition.debug;
+
+public interface IDebugDrawer {
+
+	void drawDebug();
+
+}

--- a/src/main/java/com/mrh0/createaddition/event/GameEvents.java
+++ b/src/main/java/com/mrh0/createaddition/event/GameEvents.java
@@ -2,6 +2,7 @@ package com.mrh0.createaddition.event;
 
 import com.mrh0.createaddition.blocks.connector.ConnectorMovementManager;
 import com.mrh0.createaddition.blocks.liquid_blaze_burner.LiquidBlazeBurnerBlock;
+import com.mrh0.createaddition.debug.AdditionDebugger;
 import com.mrh0.createaddition.energy.network.EnergyNetworkManager;
 import com.mrh0.createaddition.index.CABlocks;
 import com.mrh0.createaddition.index.CAItems;
@@ -33,6 +34,7 @@ public class GameEvents {
 	public static void clientTickEvent(TickEvent.ClientTickEvent evt) {
 		if(evt.phase == Phase.START) return;
 		ObservePacket.tick();
+		AdditionDebugger.tick();
 	}
 	
 	@SubscribeEvent


### PR DESCRIPTION
This _should_ fix the issue where connecters wouldn't pull/push power to accumulators, it looked like the problem was a missing flag to the setBlock method, this also fixed an issue I had where connectors / any other cable wouldn't pull any power from accumulators that had been used on a contraption (should fix both #502 & #489)

I also added a fast and easy visual debugger, basically a copy of creates KineticDebugger, I can happily remove / change it if you don't want it.