### PR TITLE
[Fabric-1.19.2] Fix: relay ignoring redstone signal

### DIFF
--- a/src/main/java/com/mrh0/createaddition/blocks/redstone_relay/RedstoneRelay.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/redstone_relay/RedstoneRelay.java
@@ -11,6 +11,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
@@ -117,13 +118,14 @@ public class RedstoneRelay extends Block implements ITE<RedstoneRelayTileEntity>
 		else
 			return defaultBlockState().setValue(HORIZONTAL_FACING, c.getClickedFace().getOpposite()).setValue(VERTICAL, true);
 	}
-	
-	public void tick(BlockState state, ServerLevel worldIn, BlockPos pos) {
+
+	@Override
+	public void tick(BlockState state, ServerLevel worldIn, BlockPos pos, RandomSource random){
 		boolean flag = state.getValue(POWERED);
 		boolean flag1 = this.shouldBePowered(worldIn, pos, state);
 		if (flag && !flag1) {
 			worldIn.setBlock(pos, state.setValue(POWERED, Boolean.FALSE), 2);
-		} 
+		}
 		else if (!flag) {
 			worldIn.setBlock(pos, state.setValue(POWERED, Boolean.TRUE), 2);
 		}
@@ -153,11 +155,9 @@ public class RedstoneRelay extends Block implements ITE<RedstoneRelayTileEntity>
 		boolean isPowered = state.getValue(POWERED);
 		boolean shouldBePowered = this.shouldBePowered(worldIn, pos, state);
 		if (isPowered != shouldBePowered && !worldIn.getBlockTicks().willTickThisTick(pos, this)) {
-			/* it appears that the scheduling did not work here, as the tick() function was not called...*/
-            /*TickPriority tickpriority = TickPriority.VERY_HIGH;
+			TickPriority tickpriority = TickPriority.VERY_HIGH;
 
-			worldIn.scheduleTick(pos, this, this.getDelay(), tickpriority);*/
-			tick(state, worldIn.getServer().getLevel(worldIn.dimension()), pos);
+			worldIn.scheduleTick(pos, this, this.getDelay(), tickpriority);
 		}
 	}
 

--- a/src/main/java/com/mrh0/createaddition/blocks/redstone_relay/RedstoneRelay.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/redstone_relay/RedstoneRelay.java
@@ -150,12 +150,14 @@ public class RedstoneRelay extends Block implements ITE<RedstoneRelayTileEntity>
 	}
 
 	protected void updateState(Level worldIn, BlockPos pos, BlockState state) {
-		boolean flag = state.getValue(POWERED);
-		boolean flag1 = this.shouldBePowered(worldIn, pos, state);
-		if (flag != flag1 && !worldIn.getBlockTicks().willTickThisTick(pos, this)) {
-			TickPriority tickpriority = TickPriority.VERY_HIGH;
+		boolean isPowered = state.getValue(POWERED);
+		boolean shouldBePowered = this.shouldBePowered(worldIn, pos, state);
+		if (isPowered != shouldBePowered && !worldIn.getBlockTicks().willTickThisTick(pos, this)) {
+			/* it appears that the scheduling did not work here, as the tick() function was not called...*/
+            /*TickPriority tickpriority = TickPriority.VERY_HIGH;
 
-			worldIn.scheduleTick(pos, this, this.getDelay(), tickpriority);
+			worldIn.scheduleTick(pos, this, this.getDelay(), tickpriority);*/
+			tick(state, worldIn.getServer().getLevel(worldIn.dimension()), pos);
 		}
 	}
 


### PR DESCRIPTION
I have found that the scheduled `tick` does not go off, which causes the block not to update the state to be powered in `tick` after `updateState` is called. ~~While this works, it is a bit hacky solution, but was unable to find any documentation on scheduleTick which coould help me figure out why the `tick` method is not called after being scheduled.~~

I have found out that the problem was the `tick` method had to have `@Override` and also use RandomSource, I implemented that instead.

fix #437 
fix #460 