### PR TITLE
[Fabric-1.19.2] Fix: rolling mill does not process items with automatic output

### DIFF
--- a/src/main/java/com/mrh0/createaddition/blocks/rolling_mill/RollingMillTileEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/rolling_mill/RollingMillTileEntity.java
@@ -5,11 +5,13 @@ import com.mrh0.createaddition.recipe.rolling.RollingRecipe;
 import com.simibubi.create.content.contraptions.base.KineticTileEntity;
 import com.simibubi.create.foundation.utility.VecHelper;
 import io.github.fabricators_of_create.porting_lib.transfer.TransferUtil;
+import io.github.fabricators_of_create.porting_lib.transfer.ViewOnlyWrappedStorageView;
 import io.github.fabricators_of_create.porting_lib.transfer.item.ItemStackHandler;
 import io.github.fabricators_of_create.porting_lib.transfer.item.ItemTransferable;
 import io.github.fabricators_of_create.porting_lib.transfer.item.RecipeWrapper;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
+import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.CombinedStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
@@ -25,8 +27,10 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -202,6 +206,36 @@ public class RollingMillTileEntity extends KineticTileEntity implements ItemTran
 		@Override
 		public long extract(ItemVariant resource, long maxAmount, TransactionContext transaction) {
 			return outputInv.extract(resource, maxAmount, transaction);
+		}
+
+		@Override
+		public @NotNull Iterator<StorageView<ItemVariant>> iterator(){
+			return new RollingMillInventoryHandlerIterator();
+		}
+
+		private class RollingMillInventoryHandlerIterator implements Iterator<StorageView<ItemVariant>> {
+			private boolean output = true;
+			private Iterator<StorageView<ItemVariant>> wrapped;
+
+			public RollingMillInventoryHandlerIterator(){
+				wrapped = outputInv.iterator();
+			}
+
+			@Override
+			public boolean hasNext(){
+				return wrapped.hasNext();
+			}
+
+			@Override
+			public StorageView<ItemVariant> next(){
+				StorageView<ItemVariant> view = wrapped.next();
+				if(!output) view = new ViewOnlyWrappedStorageView<>(view);
+				if(output && !hasNext()){
+					wrapped = inputInv.iterator();
+					output = false;
+				}
+				return view;
+			}
 		}
 	}
 


### PR DESCRIPTION
In Fabric variant of the mod, if a rolling mill had automatic output (funnel, hopper, etc) it would not process any items, but instead immediately output the item from input, e.g. copper ingot resulted with copper ingot on the output instead of expected copper rod.

This could be walked around previously by either:
 - using the rolling mill manually without any output,
 - using brass funnel with filter for expected output which would then prevent outputting the incorrect item until it is processed.

This fix changes this behaviour to make rolling mill not output input items but instead will wait for output items.

This looks related to bugs #510 and #400, however both of those are for version 1.18.2 of the mod, while this is a fix for version 1.19.2. I may backport those changes to 1.18.2 as well soon.