### PR TITLE
[Fabric-1.19.2] Fix: return copy of name to prevent infinite growing item name

### DIFF
--- a/src/main/java/com/mrh0/createaddition/index/CAFluids.java
+++ b/src/main/java/com/mrh0/createaddition/index/CAFluids.java
@@ -79,7 +79,7 @@ public class CAFluids {
 
 		@Override
 		public Component getName(FluidVariant fluidVariant) {
-			return name;
+			return name.copy();
 		}
 
 		@Override


### PR DESCRIPTION
fix #458 