### PR TITLE
Update capacitor_1.json

### DIFF
--- a/src/main/resources/data/createaddition/recipes/crafting/capacitor_1.json
+++ b/src/main/resources/data/createaddition/recipes/crafting/capacitor_1.json
@@ -9,7 +9,7 @@
 	{
 		"Z":
 		{
-			"tag": "c:plates/zinc"
+			"tag": "c:zinc_plates"
 		},
 		"C":
 		{


### PR DESCRIPTION
part 2 of fixing capacitor crafting.

These are for the compatibility with other mods that use fabric tags instead.