### PR TITLE
Fabric liquid blaze burner superheating

### DIFF
--- a/src/main/java/com/mrh0/createaddition/blocks/liquid_blaze_burner/LiquidBlazeBurnerTileEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/liquid_blaze_burner/LiquidBlazeBurnerTileEntity.java
@@ -106,6 +106,7 @@ public class LiquidBlazeBurnerTileEntity extends SmartTileEntity implements IHav
 				setBurnTag(
 					tagKey,
 					tagProperties.asResource(),
+					tagProperties.getSuperheated(),
 					tagProperties.getTime() / 100,
 					tagProperties.getDropletAmount() / 100
 				)
@@ -114,7 +115,7 @@ public class LiquidBlazeBurnerTileEntity extends SmartTileEntity implements IHav
 		if (remainingBurnTime > 0)
 			remainingBurnTime--;
 
-		if (activeFuel == FuelType.NORMAL)
+		if (activeFuel == FuelType.NORMAL || activeFuel == FuelType.SPECIAL)
 			updateBlockState();
 
 		if (remainingBurnTime > 0)
@@ -128,7 +129,7 @@ public class LiquidBlazeBurnerTileEntity extends SmartTileEntity implements IHav
 
 		updateBlockState();
 	}
-	private boolean setBurnTag(TagKey<Fluid> tagKey, ResourceLocation burnableTagLocation, int time, int fluidDropletAmount) {
+	private boolean setBurnTag(TagKey<Fluid> tagKey, ResourceLocation burnableTagLocation, boolean superheated, int time, int fluidDropletAmount) {
 		if (
 						tagKey.location().equals(burnableTagLocation) &&
 						!Transaction.isOpen() &&
@@ -139,7 +140,7 @@ public class LiquidBlazeBurnerTileEntity extends SmartTileEntity implements IHav
 			fluidTank.extract(fluidTank.variant, fluidDropletAmount, transaction);
 			transaction.commit();
 			remainingBurnTime = remainingBurnTime + time;
-			activeFuel = FuelType.NORMAL;
+			activeFuel = superheated ? FuelType.SPECIAL : FuelType.NORMAL;
 			return true;
 		}
 		return false;
@@ -153,8 +154,6 @@ public class LiquidBlazeBurnerTileEntity extends SmartTileEntity implements IHav
 			return;
 		if (remainingBurnTime > MAX_HEAT_CAPACITY)
 			return;
-
-		activeFuel = FuelType.NORMAL;
 
 		if (getHeatLevelFromBlock() != getHeatLevelFromBlock()) {
 			level.playSound(null, worldPosition, SoundEvents.BLAZE_AMBIENT, SoundSource.BLOCKS,
@@ -233,7 +232,7 @@ public class LiquidBlazeBurnerTileEntity extends SmartTileEntity implements IHav
 	}
 
 	public void updateBlockState() {
-		setBlockHeat(getHeatLevelFromFuelType(activeFuel));
+		setBlockHeat(getHeatLevelFromFuelType());
 	}
 
 	protected void setBlockHeat(HeatLevel heat) {
@@ -383,7 +382,7 @@ public class LiquidBlazeBurnerTileEntity extends SmartTileEntity implements IHav
 			.125f + level.random.nextFloat() * .125f, .75f - level.random.nextFloat() * .25f);
 	}
 
-	protected HeatLevel getHeatLevelFromFuelType(FuelType ignoredFuel) {
+	protected HeatLevel getHeatLevelFromFuelType() {
 		HeatLevel level = HeatLevel.SMOULDERING;
 		switch (activeFuel) {
 		case SPECIAL:

--- a/src/main/java/com/mrh0/createaddition/util/liquid_burning/BurnableTagProperties.java
+++ b/src/main/java/com/mrh0/createaddition/util/liquid_burning/BurnableTagProperties.java
@@ -5,11 +5,16 @@ import net.minecraft.resources.ResourceLocation;
 
 
 public class BurnableTagProperties {
+    private final boolean superheated;
     private final int time;
     private final ResourceLocation tagResource;
 
-    public BurnableTagProperties(int timePerBucket, boolean crashOnLow) {
-        this.tagResource = new ResourceLocation(CreateAddition.MODID ,"burnable_fuel_" + timePerBucket);
+    public BurnableTagProperties(boolean superheated, int timePerBucket, boolean crashOnLow) {
+        if (superheated) {
+            this.tagResource = new ResourceLocation(CreateAddition.MODID, "burnable_fuel_superheated_" + timePerBucket);
+        } else {
+            this.tagResource = new ResourceLocation(CreateAddition.MODID, "burnable_fuel_" + timePerBucket);
+        }
         if (timePerBucket < 200 && crashOnLow) {
             throw new RuntimeException("Burning Time cannot be less then 200! Change this to stop this crash " +
                     "\n[Conflicting Tag ---> " + tagResource + "]\n");
@@ -22,12 +27,17 @@ public class BurnableTagProperties {
                     "\n[Conflicting Tag ---> " + tagResource + "]\n");
         }
 
+        this.superheated = superheated;
         this.time = timePerBucket;
     }
 
     @SuppressWarnings("unused")
-    public BurnableTagProperties(int timePerBucket) {
-        this(timePerBucket, true);
+    public BurnableTagProperties(boolean superheated, int timePerBucket) {
+        this(superheated, timePerBucket, true);
+    }
+
+    public boolean getSuperheated() {
+        return this.superheated;
     }
 
     public int getTime() {

--- a/src/main/java/com/mrh0/createaddition/util/liquid_burning/FluidTagRecipeComparator.java
+++ b/src/main/java/com/mrh0/createaddition/util/liquid_burning/FluidTagRecipeComparator.java
@@ -17,23 +17,29 @@ import javax.annotation.Nullable;
  * don't need to worry about breaking changes.
  */
 public final class FluidTagRecipeComparator {
-
-   public static boolean argsToTag(Fluid fluid, Args args) {
+    public static boolean argsToTag(Fluid fluid, Args args) {
         for (TagKey<Fluid> tagKey : fluid.defaultFluidState().getTags().toList()) {
-            int i;
+            if (!tagKey.toString().contains("burnable_fuel")) {
+                continue;
+            }
+            boolean superheated = false;
+            int timePerBucket = 0;
             boolean crashOnLow = true;
+            if (tagKey.toString().contains("superheated")) {
+                superheated = true;
+            }
             try {
-                i = Integer.parseInt(tagKey
+                timePerBucket = Integer.parseInt(tagKey
                         .toString()
                         .replaceAll("[^0-9]+", " ")
                         .trim()
                 );
             } catch (NumberFormatException e) {
-                i = 0;
                 crashOnLow = false;
             }
             BurnableTagProperties tagProperties = new BurnableTagProperties(
-                    i,
+                    superheated,
+                    timePerBucket,
                     crashOnLow
             );
             Boolean bl = args.args(tagProperties, tagKey);

--- a/src/main/resources/data/createaddition/tags/fluids/burnable_fuel_superheated_12800.json
+++ b/src/main/resources/data/createaddition/tags/fluids/burnable_fuel_superheated_12800.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "createaddition:flowing_seed_oil"
+    "createaddition:bioethanol"
   ]
 }


### PR DESCRIPTION
- Adds an extensible system for marking fluids as superheating fuels via tags
- Updates liquid blaze burner tile entity to take into account fluids with superheating tags and set the appropriate heating level
- Marks bioethanol as superheating