### PR TITLE
Fabric 1.19.2 - diamond grit tag fix

### DIFF
--- a/src/main/resources/data/c/tags/items/dusts/diamond.json
+++ b/src/main/resources/data/c/tags/items/dusts/diamond.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createaddition:diamond_grit"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/dusts/obsidian.json
+++ b/src/main/resources/data/c/tags/items/dusts/obsidian.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "create:powdered_obsidian"
+  ]
+}

--- a/src/main/resources/data/createaddition/recipes/crafting/diamond_grit_sandpaper.json
+++ b/src/main/resources/data/createaddition/recipes/crafting/diamond_grit_sandpaper.json
@@ -5,7 +5,7 @@
 		    "item": "minecraft:paper"
 		},
 		{
-		    "tag": "c:diamond_dusts"
+		    "tag": "c:dusts/diamond"
 		}
 	],
 	"result":{


### PR DESCRIPTION
fixed diamond grit sandpaper being uncraftable and diamond grit not appearing under #c:diamond_dusts by conforming to forge versioning tags of c:dusts/diamond for fabric 1.19.2