### PR TITLE
Fabric 1.19.2: Fix scope on getHeatLevelFromFuelType

### DIFF
--- a/src/main/java/com/mrh0/createaddition/blocks/liquid_blaze_burner/LiquidBlazeBurnerBlockEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/liquid_blaze_burner/LiquidBlazeBurnerBlockEntity.java
@@ -421,7 +421,7 @@ public class LiquidBlazeBurnerBlockEntity extends SmartBlockEntity implements IH
 
 	protected BlazeBurnerBlock.HeatLevel getHeatLevelFromFuelType(FuelType fuel) {
 		BlazeBurnerBlock.HeatLevel level = BlazeBurnerBlock.HeatLevel.SMOULDERING;
-		switch (activeFuel) {
+		switch (fuel) {
 		case SPECIAL:
 			level = BlazeBurnerBlock.HeatLevel.SEETHING;
 			break;


### PR DESCRIPTION
The method getHeatLevelFromFuelType accepts an argument for fuel, but then uses the class attribute instead of the argument. This fixes that. 