### PR TITLE
Fix World Memory Leak

### DIFF
--- a/src/main/java/com/mrh0/createaddition/energy/network/EnergyNetworkManager.java
+++ b/src/main/java/com/mrh0/createaddition/energy/network/EnergyNetworkManager.java
@@ -2,14 +2,11 @@ package com.mrh0.createaddition.energy.network;
 
 import net.minecraft.world.level.LevelAccessor;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 
 public class EnergyNetworkManager {
-	public static Map<LevelAccessor, EnergyNetworkManager> instances = new HashMap<>();
+	public static Map<LevelAccessor, EnergyNetworkManager> instances = new WeakHashMap<>();
 	
 	private List<EnergyNetwork> networks;
 	


### PR DESCRIPTION
The `EnergyNetworkManager.instances` map keeps world references in memory forever causing memory leaks as players leave and join worlds. This makes it impossible to load into more than a handful of worlds before requiring a restart in several modpacks. This PR fixes the memory leak using a `WeakHashMap` which won't prevent the garbage collector from discarding the world instance when it is no longer used. For the future, a proper solution would be to store the `EnergyNetworkManager` on the world directly through a mixin. 