### PR TITLE
Change c:glass tag to c:glass_blocks in recipes 

### DIFF
--- a/src/main/resources/data/createaddition/recipes/compat/tconstruct/tinkers_bronze.json
+++ b/src/main/resources/data/createaddition/recipes/compat/tconstruct/tinkers_bronze.json
@@ -11,7 +11,7 @@
       "tag": "c:ingots/copper"
     },
     {
-      "tag": "c:glass"
+      "tag": "c:glass_blocks"
     }
   ],
   "results": [

--- a/src/main/resources/data/createaddition/recipes/crafting/small_light_connector.json
+++ b/src/main/resources/data/createaddition/recipes/crafting/small_light_connector.json
@@ -5,7 +5,7 @@
 		    "tag": "c:wires/iron"
 		},
 		{
-		    "tag": "c:glass"
+		    "tag": "c:glass_blocks"
 		},
 		{
 		    "item": "createaddition:connector"


### PR DESCRIPTION
No idea if this is the right fix, I havent compiled the mod and tested it, but there is no c:glass item tag for glass blocks, therefore breaking this recipe for Fabric 1.20.1