### PR TITLE
Treated wood planks from thermal creosote

### DIFF
--- a/src/main/resources/data/createaddition/recipes/filling/treated_wood_planks.json
+++ b/src/main/resources/data/createaddition/recipes/filling/treated_wood_planks.json
@@ -5,7 +5,7 @@
       "tag": "minecraft:planks"
     },
     {
-      "fluid": "immersiveengineering:creosote",
+      "fluid": "forge:creosote",
       "amount": 125
     }
   ],


### PR DESCRIPTION
Allow use of both Immersive Engineering's creosote oil and Thermal's creosote oil in the creation of treated planks using a Spout (and potentially others)