### PR TITLE
[Fabric] Stop double-counting liquid blaze burner fuel use

### DIFF
--- a/src/main/java/com/mrh0/createaddition/blocks/liquid_blaze_burner/LiquidBlazeBurnerBlockEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/liquid_blaze_burner/LiquidBlazeBurnerBlockEntity.java
@@ -207,9 +207,6 @@ public class LiquidBlazeBurnerBlockEntity extends SmartBlockEntity implements IH
 			return;
 		}
 		
-		if (remainingBurnTime > 0)
-			remainingBurnTime--;
-
 		if (remainingBurnTime > 0 && !isCreative)
 			remainingBurnTime--;
 


### PR DESCRIPTION
Fixes #782.  This is not quite equivalent to the Forge implementation, because I didn't want to worry about that implementing off-by-one errors (see the referenced issue), but does work with brief testing.