### PR TITLE
Update 1.19.2 biomass item with two tags

### DIFF
--- a/src/main/resources/data/forge/tags/items/fuels.json
+++ b/src/main/resources/data/forge/tags/items/fuels.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createaddition:biomass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fuels/bio.json
+++ b/src/main/resources/data/forge/tags/items/fuels/bio.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "createaddition:biomass"
+  ]
+}


### PR DESCRIPTION
With this change, the item now counts as a fuel and biomass.

Example of it working:
![image](https://github.com/user-attachments/assets/0dc145fd-74d6-4785-af90-4123db1c387c)
