### PR TITLE
Fix diamond grit sandpaper's incorrect use animation

### DIFF
--- a/src/main/java/com/mrh0/createaddition/index/CAItems.java
+++ b/src/main/java/com/mrh0/createaddition/index/CAItems.java
@@ -6,6 +6,7 @@ import com.mrh0.createaddition.item.ElectrumAmulet;
 import com.mrh0.createaddition.item.WireSpool;
 import com.mrh0.createaddition.item.BiomassPellet;
 import com.mrh0.createaddition.item.DiamondGritSandpaper;
+import com.simibubi.create.content.equipment.sandPaper.SandPaperItemRenderer;
 import com.simibubi.create.foundation.data.CreateRegistrate;
 import com.tterrag.registrate.util.entry.ItemEntry;
 import net.minecraft.world.item.Item;
@@ -28,7 +29,9 @@ public class CAItems {
 			CreateAddition.REGISTRATE.item("diamond_grit", Item::new)
 			.register();
 
-	public static final ItemEntry<DiamondGritSandpaper> DIAMOND_GRIT_SANDPAPER = CreateAddition.REGISTRATE.item("diamond_grit_sandpaper", DiamondGritSandpaper::new)
+	public static final ItemEntry<DiamondGritSandpaper> DIAMOND_GRIT_SANDPAPER =
+		CreateAddition.REGISTRATE.item("diamond_grit_sandpaper", DiamondGritSandpaper::new)
+			.transform(CreateRegistrate.customRenderedItem(() -> SandPaperItemRenderer::new))
 			.register();
 	
 	public static final ItemEntry<Item> BIOMASS =


### PR DESCRIPTION
Changes it from the normal eating animation to the in-built Create sand paper one. Fixes #779