### PR TITLE
Ponder Categories

### DIFF
--- a/src/main/java/com/mrh0/createaddition/index/CAPonders.java
+++ b/src/main/java/com/mrh0/createaddition/index/CAPonders.java
@@ -31,10 +31,6 @@ public class CAPonders {
 				.add(CABlocks.ROLLING_MILL)
 				.add(CABlocks.ALTERNATOR);
 
-		HELPER.addToTag(AllCreatePonderTags.LOGISTICS)
-				.add(CABlocks.TESLA_COIL)
-				.add(CABlocks.MODULAR_ACCUMULATOR);
-
 		HELPER.addToTag(AllCreatePonderTags.CONTRAPTION_ACTOR)
 				.add(CABlocks.PORTABLE_ENERGY_INTERFACE);
 
@@ -53,11 +49,11 @@ public class CAPonders {
 		HELPER.addStoryBoard(CABlocks.ALTERNATOR, "alternator", PonderScenes::alternator, AllCreatePonderTags.KINETIC_APPLIANCES, ELECTRIC);
 		HELPER.addStoryBoard(CABlocks.ROLLING_MILL, "rolling_mill", PonderScenes::rollingMill, AllCreatePonderTags.KINETIC_APPLIANCES);
 		HELPER.addStoryBoard(CABlocks.ROLLING_MILL, "automate_rolling_mill", PonderScenes::automateRollingMill, AllCreatePonderTags.KINETIC_APPLIANCES);
-		HELPER.addStoryBoard(CABlocks.TESLA_COIL, "tesla_coil", PonderScenes::teslaCoil, AllCreatePonderTags.LOGISTICS, ELECTRIC);
-		HELPER.addStoryBoard(CABlocks.TESLA_COIL, "tesla_coil_hurt", PonderScenes::teslaCoilHurt, AllCreatePonderTags.LOGISTICS, ELECTRIC);
+		HELPER.addStoryBoard(CABlocks.TESLA_COIL, "tesla_coil", PonderScenes::teslaCoil, ELECTRIC);
+		HELPER.addStoryBoard(CABlocks.TESLA_COIL, "tesla_coil_hurt", PonderScenes::teslaCoilHurt, ELECTRIC);
 		HELPER.addStoryBoard(CAItems.STRAW, "liquid_blaze_burner", PonderScenes::liquidBlazeBurner, AllCreatePonderTags.LOGISTICS);
 		HELPER.addStoryBoard(AllBlocks.BLAZE_BURNER, "liquid_blaze_burner", PonderScenes::liquidBlazeBurner, AllCreatePonderTags.LOGISTICS);
-		HELPER.addStoryBoard(CABlocks.MODULAR_ACCUMULATOR, "accumulator", PonderScenes::modularAccumulator, AllCreatePonderTags.LOGISTICS, ELECTRIC);
+		HELPER.addStoryBoard(CABlocks.MODULAR_ACCUMULATOR, "accumulator", PonderScenes::modularAccumulator, ELECTRIC);
 		HELPER.addStoryBoard(CABlocks.PORTABLE_ENERGY_INTERFACE, "pei_transfer", PonderScenes::peiTransfer, AllCreatePonderTags.CONTRAPTION_ACTOR, ELECTRIC);
 		HELPER.addStoryBoard(CABlocks.PORTABLE_ENERGY_INTERFACE, "pei_redstone", PonderScenes::peiRedstone, AllCreatePonderTags.CONTRAPTION_ACTOR, ELECTRIC);
 		

--- a/src/main/java/com/mrh0/createaddition/index/CAPonders.java
+++ b/src/main/java/com/mrh0/createaddition/index/CAPonders.java
@@ -31,6 +31,9 @@ public class CAPonders {
 				.add(CABlocks.ROLLING_MILL)
 				.add(CABlocks.ALTERNATOR);
 
+		HELPER.addToTag(AllCreatePonderTags.FLUIDS)
+				.add(CAItems.STRAW);
+
 		HELPER.addToTag(AllCreatePonderTags.CONTRAPTION_ACTOR)
 				.add(CABlocks.PORTABLE_ENERGY_INTERFACE);
 
@@ -51,7 +54,7 @@ public class CAPonders {
 		HELPER.addStoryBoard(CABlocks.ROLLING_MILL, "automate_rolling_mill", PonderScenes::automateRollingMill, AllCreatePonderTags.KINETIC_APPLIANCES);
 		HELPER.addStoryBoard(CABlocks.TESLA_COIL, "tesla_coil", PonderScenes::teslaCoil, ELECTRIC);
 		HELPER.addStoryBoard(CABlocks.TESLA_COIL, "tesla_coil_hurt", PonderScenes::teslaCoilHurt, ELECTRIC);
-		HELPER.addStoryBoard(CAItems.STRAW, "liquid_blaze_burner", PonderScenes::liquidBlazeBurner, AllCreatePonderTags.LOGISTICS);
+		HELPER.addStoryBoard(CAItems.STRAW, "liquid_blaze_burner", PonderScenes::liquidBlazeBurner, AllCreatePonderTags.FLUIDS);
 		HELPER.addStoryBoard(AllBlocks.BLAZE_BURNER, "liquid_blaze_burner", PonderScenes::liquidBlazeBurner, AllCreatePonderTags.LOGISTICS);
 		HELPER.addStoryBoard(CABlocks.MODULAR_ACCUMULATOR, "accumulator", PonderScenes::modularAccumulator, ELECTRIC);
 		HELPER.addStoryBoard(CABlocks.PORTABLE_ENERGY_INTERFACE, "pei_transfer", PonderScenes::peiTransfer, AllCreatePonderTags.CONTRAPTION_ACTOR, ELECTRIC);

--- a/src/main/java/com/mrh0/createaddition/index/CAPonders.java
+++ b/src/main/java/com/mrh0/createaddition/index/CAPonders.java
@@ -33,7 +33,9 @@ public class CAPonders {
 
 		HELPER.addToTag(AllCreatePonderTags.LOGISTICS)
 				.add(CABlocks.TESLA_COIL)
-				.add(CABlocks.MODULAR_ACCUMULATOR)
+				.add(CABlocks.MODULAR_ACCUMULATOR);
+
+		HELPER.addToTag(AllCreatePonderTags.CONTRAPTION_ACTOR)
 				.add(CABlocks.PORTABLE_ENERGY_INTERFACE);
 
 		HELPER.addToTag(ELECTRIC)
@@ -56,8 +58,8 @@ public class CAPonders {
 		HELPER.addStoryBoard(CAItems.STRAW, "liquid_blaze_burner", PonderScenes::liquidBlazeBurner, AllCreatePonderTags.LOGISTICS);
 		HELPER.addStoryBoard(AllBlocks.BLAZE_BURNER, "liquid_blaze_burner", PonderScenes::liquidBlazeBurner, AllCreatePonderTags.LOGISTICS);
 		HELPER.addStoryBoard(CABlocks.MODULAR_ACCUMULATOR, "accumulator", PonderScenes::modularAccumulator, AllCreatePonderTags.LOGISTICS, ELECTRIC);
-		HELPER.addStoryBoard(CABlocks.PORTABLE_ENERGY_INTERFACE, "pei_transfer", PonderScenes::peiTransfer, AllCreatePonderTags.LOGISTICS, ELECTRIC);
-		HELPER.addStoryBoard(CABlocks.PORTABLE_ENERGY_INTERFACE, "pei_redstone", PonderScenes::peiRedstone, AllCreatePonderTags.LOGISTICS, ELECTRIC);
+		HELPER.addStoryBoard(CABlocks.PORTABLE_ENERGY_INTERFACE, "pei_transfer", PonderScenes::peiTransfer, AllCreatePonderTags.CONTRAPTION_ACTOR, ELECTRIC);
+		HELPER.addStoryBoard(CABlocks.PORTABLE_ENERGY_INTERFACE, "pei_redstone", PonderScenes::peiRedstone, AllCreatePonderTags.CONTRAPTION_ACTOR, ELECTRIC);
 		
 		
 		if(CreateAddition.CC_ACTIVE)


### PR DESCRIPTION
I've found the placement of PonderScenes within the PonderIndex categories confusing.
Following are some changes that better reflect what usage each scene is teaching.

This is more of an overall suggestion, than a contribution specific to this branch.
If you agree with those changes, they should probably be applied to multiple branches.
