### PR TITLE
fix: properly render straw model with ImmediatelyFast

### DIFF
--- a/src/main/resources/assets/createaddition/models/entity/liquid_hat.json
+++ b/src/main/resources/assets/createaddition/models/entity/liquid_hat.json
@@ -41,24 +41,6 @@
 			}
 		},
 		{
-			"from": [-4.7, -4, -2.3],
-			"to": [4.7, 0, 4.7],
-			"rotation": {"angle": 0, "axis": "y", "origin": [0, 0, -1.5]},
-			"faces": {
-				"east": {"uv": [9, 12, 16, 16], "texture": "#2"},
-				"south": {"uv": [4, 12, 11, 16], "texture": "#2"}
-			}
-		},
-		{
-			"from": [-6, 3, -0.3],
-			"to": [6, 7, -0.3],
-			"rotation": {"angle": 0, "axis": "y", "origin": [0, 0, -1.5]},
-			"faces": {
-				"north": {"uv": [16, 0, 4, 4], "texture": "#2"},
-				"south": {"uv": [4, 0, 16, 4], "texture": "#2"}
-			}
-		},
-		{
 			"from": [-4.5, 1.3961, 4.04328],
 			"to": [4.5, 2.3961, 6.04328],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [0, 0, -1.5]},
@@ -121,6 +103,146 @@
 				"south": {"uv": [0, 9, 3, 12], "texture": "#2"},
 				"west": {"uv": [0, 9, 3, 12], "texture": "#2"}
 			}
+		},
+		{
+			"from": [0.7, -4, 4.7],
+			"to": [4.7, -3, 4.7],
+			"rotation": {"angle": 0, "axis": "y", "origin": [1, -4, 4]},
+			"faces": {
+				"north": {"uv": [11, 15, 8, 16], "texture": "#2"},
+				"east": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"south": {"uv": [8, 15, 11, 16], "texture": "#2"},
+				"west": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"up": {"uv": [0, 0, 4, 0.3], "texture": "#2"},
+				"down": {"uv": [0, 0, 4, 0.3], "texture": "#2"}
+			}
+		},
+		{
+			"from": [4.7, -4, 0.7],
+			"to": [4.7, -3, 4.7],
+			"rotation": {"angle": 0, "axis": "y", "origin": [4, -4, 4]},
+			"faces": {
+				"north": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"east": {"uv": [9, 15, 13, 16], "texture": "#2"},
+				"south": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"west": {"uv": [13, 15, 9, 16], "texture": "#2"},
+				"up": {"uv": [0, 0, 4, 0.3], "rotation": 270, "texture": "#2"},
+				"down": {"uv": [0, 0, 4, 0.3], "rotation": 90, "texture": "#2"}
+			}
+		},
+		{
+			"from": [4.7, -3, -0.3],
+			"to": [4.7, -2, 0.7],
+			"rotation": {"angle": 0, "axis": "y", "origin": [4, -3, 3]},
+			"faces": {
+				"north": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"east": {"uv": [13, 14, 14, 15], "texture": "#2"},
+				"south": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"west": {"uv": [13, 14, 14, 15], "texture": "#2"},
+				"up": {"uv": [0, 0, 4, 0.3], "rotation": 270, "texture": "#2"},
+				"down": {"uv": [0, 0, 4, 0.3], "rotation": 90, "texture": "#2"}
+			}
+		},
+		{
+			"from": [4.7, -2, -1.3],
+			"to": [4.7, 0, -0.3],
+			"rotation": {"angle": 0, "axis": "y", "origin": [4, -2, 2]},
+			"faces": {
+				"north": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"east": {"uv": [14, 12, 15, 14], "texture": "#2"},
+				"south": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"west": {"uv": [14, 12, 15, 14], "texture": "#2"},
+				"up": {"uv": [0, 0, 4, 0.3], "rotation": 270, "texture": "#2"},
+				"down": {"uv": [0, 0, 4, 0.3], "rotation": 90, "texture": "#2"}
+			}
+		},
+		{
+			"from": [-5, 5, -0.3],
+			"to": [-2, 6, -0.3],
+			"rotation": {"angle": 0, "axis": "y", "origin": [1, -4, 4]},
+			"faces": {
+				"north": {"uv": [8, 1, 5, 2], "texture": "#2"},
+				"east": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"south": {"uv": [5, 1, 8, 2], "texture": "#2"},
+				"west": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"up": {"uv": [0, 0, 4, 0.3], "texture": "#2"},
+				"down": {"uv": [0, 0, 4, 0.3], "texture": "#2"}
+			}
+		},
+		{
+			"from": [-2, 4, -0.3],
+			"to": [0, 5, -0.3],
+			"rotation": {"angle": 0, "axis": "y", "origin": [1, -4, 4]},
+			"faces": {
+				"north": {"uv": [10, 2, 8, 3], "texture": "#2"},
+				"east": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"south": {"uv": [8, 2, 10, 3], "texture": "#2"},
+				"west": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"up": {"uv": [0, 0, 4, 0.3], "texture": "#2"},
+				"down": {"uv": [0, 0, 4, 0.3], "texture": "#2"}
+			}
+		},
+		{
+			"from": [0, 5, -0.3],
+			"to": [2, 6, -0.3],
+			"rotation": {"angle": 0, "axis": "y", "origin": [1, -4, 4]},
+			"faces": {
+				"north": {"uv": [12, 1, 10, 2], "texture": "#2"},
+				"east": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"south": {"uv": [10, 1, 12, 2], "texture": "#2"},
+				"west": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"up": {"uv": [0, 0, 4, 0.3], "texture": "#2"},
+				"down": {"uv": [0, 0, 4, 0.3], "texture": "#2"}
+			}
+		},
+		{
+			"from": [2, 6, -0.3],
+			"to": [4, 7, -0.3],
+			"rotation": {"angle": 0, "axis": "y", "origin": [1, -4, 4]},
+			"faces": {
+				"north": {"uv": [14, 0, 12, 1], "texture": "#2"},
+				"east": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"south": {"uv": [12, 0, 14, 1], "texture": "#2"},
+				"west": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"up": {"uv": [0, 0, 4, 0.3], "texture": "#2"},
+				"down": {"uv": [0, 0, 4, 0.3], "texture": "#2"}
+			}
+		},
+		{
+			"from": [4, 5, -0.3],
+			"to": [5, 6, -0.3],
+			"rotation": {"angle": 0, "axis": "y", "origin": [1, -4, 4]},
+			"faces": {
+				"north": {"uv": [15, 1, 14, 2], "texture": "#2"},
+				"east": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"south": {"uv": [14, 1, 15, 2], "texture": "#2"},
+				"west": {"uv": [0, 0, 0.3, 1], "texture": "#2"},
+				"up": {"uv": [0, 0, 4, 0.3], "texture": "#2"},
+				"down": {"uv": [0, 0, 4, 0.3], "texture": "#2"}
+			}
+		}
+	],
+	"groups": [
+		0,
+		1,
+		2,
+		3,
+		4,
+		5,
+		6,
+		7,
+		8,
+		{
+			"name": "Bottom Straw",
+			"origin": [8, 8, 8],
+			"color": 0,
+			"children": [9, 10, 11, 12]
+		},
+		{
+			"name": "Top Straw",
+			"origin": [8, 8, 8],
+			"color": 0,
+			"children": [13, 14, 15, 16, 17]
 		}
 	]
 }


### PR DESCRIPTION
# Fix for Transparent Pixels Rendering Incorrectly with ImmediatelyFast Installed

## What's going on?
When ImmediatelyFast is installed, some transparent pixels in the entity model (specifically the straw texture) would render weirdly or not show up at all.  
Not 100% sure what's happening internally, but it seems large cubes with a lot of transparent areas don't play nicely with how ImmediatelyFast optimizes rendering.

## What I changed
Instead of using two big cubes that covered the entire straw texture (including transparent parts), I split them into **smaller cubes** that only cover the actual visible parts of the texture.  
This way, no invisible faces are being rendered, and the model now looks correct even with ImmediatelyFast installed.

## Before & After
- Before Fix (ImmediatelyFast enabled)
 ![image](https://github.com/user-attachments/assets/1bdd9216-f593-4959-b686-2330ae5ba089)
 
- After Fix (ImmediatelyFast enabled)
![image](https://github.com/user-attachments/assets/c42e0eb9-affd-4f76-8620-fa38fc64abde)


## Related Issue
- [Issue on ImmediatelyFast GitHub](https://github.com/RaphiMC/ImmediatelyFast/issues/322)
