### PR TITLE
Update `c/plates` tag

### DIFF
--- a/src/generated/resources/data/c/tags/item/plates.json
+++ b/src/generated/resources/data/c/tags/item/plates.json
@@ -1,6 +1,6 @@
 {
   "values": [
-    "#c:ingots/electrum",
+    "#c:plates/electrum",
     "#c:plates/zinc"
   ]
 }


### PR DESCRIPTION
- Replaced Electrum Ingot with Electrum Sheet in `#c:plates` tag.

I don't think it's intentional, since there's Electrum Sheet that has no tags at all:
![image](https://github.com/user-attachments/assets/77a51ce2-2190-4620-a776-86ee1c7012ae)
![image](https://github.com/user-attachments/assets/2394af27-4e04-4a6d-92c8-3036e22fb331)
