### PR TITLE
Fixed Portable Energy Interface (neoforge 1.21.1)

### DIFF
--- a/src/main/java/com/mrh0/createaddition/blocks/portable_energy_interface/PortableEnergyInterfaceBlockEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/portable_energy_interface/PortableEnergyInterfaceBlockEntity.java
@@ -37,6 +37,7 @@ public class PortableEnergyInterfaceBlockEntity extends PortableStorageInterface
 
 	public void startTransferringTo(Contraption contraption, float distance) {
 		IEnergyStorage oldcap = this.capability;
+		invalidate();
 		this.capability =  new InterfaceEnergyHandler(PortableEnergyManager.get(contraption));
 		//oldcap.invalidate();
 		super.startTransferringTo(contraption, distance);
@@ -52,6 +53,7 @@ public class PortableEnergyInterfaceBlockEntity extends PortableStorageInterface
 	@Override
 	protected void stopTransferring() {
 		IEnergyStorage oldcap = this.capability;
+		invalidate();
 		this.capability = this.createEmptyHandler();
 		//oldcap.invalidate();
 		super.stopTransferring();


### PR DESCRIPTION
The Portable Energy Interface seems to work again if the capabilities saved for the PortableEnergyInterfaceBlockEntity get invalidated

(#925)