### PR TITLE
Possibly fix CASoundScapes crash

### DIFF
--- a/src/main/java/com/mrh0/createaddition/event/ClientEventHandler.java
+++ b/src/main/java/com/mrh0/createaddition/event/ClientEventHandler.java
@@ -12,6 +12,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.RegisterClientReloadListenersEvent;
+import net.neoforged.neoforge.event.tick.LevelTickEvent;
 
 @EventBusSubscriber(modid = CreateAddition.MODID, bus = EventBusSubscriber.Bus.GAME, value = Dist.CLIENT)
 public class ClientEventHandler {
@@ -28,8 +29,10 @@ public class ClientEventHandler {
     }
 
     @SubscribeEvent
-    public static void tickSoundscapes(ClientTickEvent.Post event) {
-        CASoundScapes.tick();
+    public static void tickSoundscapes(LevelTickEvent.Post event) {
+        if(event.getLevel().isClientSide) {
+            CASoundScapes.tick();
+        }
     }
 
     @EventBusSubscriber(value = Dist.CLIENT, bus = EventBusSubscriber.Bus.MOD)


### PR DESCRIPTION
## Pull Request Checklist

Please review and complete all items before submitting your pull request:

- [x] I have thoroughly tested the changes and verified they work as expected.
- [x] The code follows the coding standards and best practices of the project.
- [x] I have reviewed the changes for potential security or performance issues.

## MIT License Confirmation

- [x] I confirm that all code included in this PR is compatible with the [MIT License](https://opensource.org/licenses/MIT).
- [x] I understand and accept that, by submitting this pull request, all contributions are permanently licensed under the MIT License, and I waive any rights to revoke or change the license in the future.

## Description

This Pull request changes CASoundScapes so that it is ticked only when you are in a world. 

## Related Issues

Might fix #963, but I don't know because I can't reproduce it.
