### PR TITLE
Reverted biofuel burnTime in liquid blaze burner to 24000

### DIFF
--- a/src/generated/resources/data/createaddition/recipe/liquid_burning/biofuel.json
+++ b/src/generated/resources/data/createaddition/recipe/liquid_burning/biofuel.json
@@ -1,6 +1,6 @@
 {
   "type": "createaddition:liquid_burning",
-  "burn_time": 2400,
+  "burn_time": 24000,
   "ingredients": [
     {
       "type": "fluid_tag",


### PR DESCRIPTION
## Pull Request Checklist

Please review and complete all items before submitting your pull request:

- [x] I have thoroughly tested the changes and verified they work as expected.
- [x] The code follows the coding standards and best practices of the project.
- [x] I have reviewed the changes for potential security or performance issues.

## MIT License Confirmation

- [x] I confirm that all code included in this PR is compatible with the [MIT License](https://opensource.org/licenses/MIT).
- [x] I understand and accept that, by submitting this pull request, all contributions are permanently licensed under the MIT License, and I waive any rights to revoke or change the license in the future.

## Description

Reverts the burnTime for biofuel in a liquid blaze burner to its previous value of 24000, instead of 2400.

## Related Issues

Closes #1094 
