### PR TITLE
Fix StackOverflowError in ModularAccumulatorBlockEntity.handlerForCap…

### DIFF
--- a/src/main/java/com/mrh0/createaddition/blocks/modular_accumulator/ModularAccumulatorBlockEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/modular_accumulator/ModularAccumulatorBlockEntity.java
@@ -324,8 +324,12 @@ public class ModularAccumulatorBlockEntity extends SmartBlockEntity implements I
 	}
 
 	private InternalEnergyStorage handlerForCapability() {
-		return isController() ? energyCapability
-			: (getControllerBE() != null ? getControllerBE().handlerForCapability() : new InternalEnergyStorage(0, CommonConfig.ACCUMULATOR_MAX_INPUT.get(), CommonConfig.ACCUMULATOR_MAX_OUTPUT.get()));
+		if (isController()) return energyCapability;
+		ModularAccumulatorBlockEntity controllerBE = getControllerBE();
+		if (controllerBE != null && controllerBE != this) {
+			return controllerBE.handlerForCapability();
+		}
+		return new InternalEnergyStorage(0, CommonConfig.ACCUMULATOR_MAX_INPUT.get(), CommonConfig.ACCUMULATOR_MAX_OUTPUT.get());
 	}
 
 	@Override


### PR DESCRIPTION
## Pull Request Checklist

Please review and complete all items before submitting your pull request:

- [x] I have thoroughly tested the changes and verified they work as expected.
- [x] The code follows the coding standards and best practices of the project.
- [x] I have reviewed the changes for potential security or performance issues.

## MIT License Confirmation

- [x] I confirm that all code included in this PR is compatible with the [MIT License](https://opensource.org/licenses/MIT).
- [x] I understand and accept that, by submitting this pull request, all contributions are permanently licensed under the MIT License, and I waive any rights to revoke or change the license in the future.

## Description

### Crash Cause

ModularAccumulatorBlockEntity.handlerForCapability() has a recursive call defect.

When getControllerBE() returns this under certain conditions (e.g., level == null or chunk not loaded) while isController() returns false, it causes handlerForCapability() to infinitely recurse, resulting in a StackOverflowError.

### Fix Summary

Added controllerBE != this check in handlerForCapability() to prevent the method from recursively calling itself.

```java
// Before
private InternalEnergyStorage handlerForCapability() {
    return isController() ? energyCapability
        : (getControllerBE() != null
            ? getControllerBE().handlerForCapability()
            : new InternalEnergyStorage(0, ...));
}

// After
private InternalEnergyStorage handlerForCapability() {
    if (isController()) return energyCapability;

    ModularAccumulatorBlockEntity controllerBE = getControllerBE();
    if (controllerBE != null && controllerBE != this) {
        return controllerBE.handlerForCapability();
    }

    return new InternalEnergyStorage(0, ...);
}

