### PR TITLE
1.21.1 fixgirder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
-    id 'net.neoforged.moddev' version '2.0.99'
+    id 'net.neoforged.moddev' version '2.0.141'
     id 'idea'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/assets/createaddition/models/block/connector/girder_base.json
+++ b/src/main/resources/assets/createaddition/models/block/connector/girder_base.json
@@ -2,7 +2,7 @@
 	"credit": "Made with Blockbench",
 	"textures": {
 		"0": "create:block/girder",
-		"particle": "create:block/chute_block"
+		"particle": "create:block/industrial_iron_block"
 	},
 	"elements": [
 		{


### PR DESCRIPTION
## Pull Request Checklist

Please review and complete all items before submitting your pull request:

- [x] I have thoroughly tested the changes and verified they work as expected.
- [x] The code follows the coding standards and best practices of the project.
- [x] I have reviewed the changes for potential security or performance issues.

## MIT License Confirmation

- [x] I confirm that all code included in this PR is compatible with the [MIT License](https://opensource.org/licenses/MIT).
- [x] I understand and accept that, by submitting this pull request, all contributions are permanently licensed under the MIT License, and I waive any rights to revoke or change the license in the future.

## Description

girder_base.json file references texture "create:block/chute_block" as particle but it does not exist anymore. I assume it's supposed to have same particle as non-windowed chute? It's industrial_iron_block now and after this change the texture error does not appear anymore.
Though this change is not visible in game, as connectors on girder uses andesite casing particle instead. but I'm sending this PR anyway because it is possible to later use this particle as well. and it does remove one warning so that's cool.