### PR TITLE
Aeronautics Simulated Docking compat

### DIFF
--- a/src/main/java/com/mrh0/createaddition/CreateAddition.java
+++ b/src/main/java/com/mrh0/createaddition/CreateAddition.java
@@ -60,7 +60,7 @@ public class CreateAddition {
     public static boolean CC_ACTIVE = false;
     public static boolean AE2_ACTIVE = false;
     public static boolean MEK_ACTIVE = false;
-
+    public static boolean SIM_ACTIVE = false;
     public static final CreateRegistrate REGISTRATE = CreateRegistrate.create(CreateAddition.MODID)
             .defaultCreativeTab((ResourceKey<CreativeModeTab>) null)
             .setTooltipModifierFactory(item ->
@@ -117,6 +117,7 @@ public class CreateAddition {
         CC_ACTIVE = ModList.get().isLoaded("computercraft");
         AE2_ACTIVE = ModList.get().isLoaded("ae2");
         MEK_ACTIVE = ModList.get().isLoaded("mekanism");
+        SIM_ACTIVE = ModList.get().isLoaded("simulated");
 
         REGISTRATE.registerEventListeners(eventBus);
         CABlocks.register();

--- a/src/main/java/com/mrh0/createaddition/compat/simulated/DockEnergyStorage.java
+++ b/src/main/java/com/mrh0/createaddition/compat/simulated/DockEnergyStorage.java
@@ -1,0 +1,104 @@
+package com.mrh0.createaddition.compat.simulated;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.neoforged.neoforge.energy.IEnergyStorage;
+
+public class DockEnergyStorage implements IEnergyStorage {
+
+    private final BlockEntity blockEntity;
+    private int energy;
+    private final int capacity;
+    private BlockPos connectedPos;
+    private DockEnergyStorage connectedStorage;
+    private boolean isPrimary;
+
+
+
+    public DockEnergyStorage(BlockEntity  be, int capacity) {
+        this.blockEntity = be;
+        this.capacity = capacity;
+    }
+
+    public void connect(BlockPos pos, DockEnergyStorage other) {
+        this.connectedPos = pos;
+        this.connectedStorage = other;
+
+        // invalidate so the connector cache rebuilds
+        this.isPrimary = blockEntity.getBlockPos().compareTo(pos) < 0;
+        if (this.blockEntity.getLevel() != null  && !blockEntity.getLevel().isClientSide()) {
+            this.blockEntity.getLevel().invalidateCapabilities(this.blockEntity.getBlockPos());
+        }
+    }
+
+    public void disconnect() {
+        this.connectedPos = null;
+        this.connectedStorage = null;
+        this.isPrimary = false;
+
+        if (this.blockEntity.getLevel() != null  && !blockEntity.getLevel().isClientSide()) {
+            this.blockEntity.getLevel().invalidateCapabilities(this.blockEntity.getBlockPos());
+        }
+    }
+
+
+    public boolean isConnected() {
+        if (connectedPos == null) return false;
+        if (blockEntity.getLevel() == null) return false;
+        if (blockEntity.getLevel().isClientSide()) return  false;
+
+        BlockEntity other = blockEntity.getLevel().getBlockEntity(connectedPos);
+
+        if (other instanceof DockingConnectorBEAccess access) {
+            return access.getEnergyStorage().connectedStorage == this;
+        }
+        return false;
+    }
+
+
+    private DockEnergyStorage getStorage() {
+        return isPrimary ? this : connectedStorage;
+    }
+
+    @Override
+    public int receiveEnergy(int maxReceive, boolean simulate) {
+        if (!isConnected()) return 0;
+        DockEnergyStorage storage = getStorage();
+        int canAccept = storage.capacity - storage.energy;
+        int toStore = Math.min(canAccept, maxReceive);
+        if (!simulate) storage.energy += toStore;
+        return toStore;
+    }
+
+    @Override
+    public int extractEnergy(int maxExtract, boolean simulate) {
+        if (!isConnected()) return 0;
+        DockEnergyStorage storage = getStorage();
+        int toExtract = Math.min(storage.energy, maxExtract);
+        if (!simulate) storage.energy -= toExtract;
+        return toExtract;
+    }
+
+    @Override
+    public int getEnergyStored() {
+        if (!isConnected()) return 0;
+        return getStorage().energy;
+    }
+
+    @Override
+    public int getMaxEnergyStored() {
+        if (!isConnected()) return 0;
+        return getStorage().capacity;
+    }
+
+    @Override
+    public boolean canExtract() { return isConnected(); }
+
+    @Override
+    public boolean canReceive() { return isConnected(); }
+
+
+    public DockEnergyStorage getConnectedStorage() {
+        return connectedStorage;
+    }
+}

--- a/src/main/java/com/mrh0/createaddition/compat/simulated/DockEnergyStorage.java
+++ b/src/main/java/com/mrh0/createaddition/compat/simulated/DockEnergyStorage.java
@@ -36,6 +36,7 @@ public class DockEnergyStorage implements IEnergyStorage {
         this.connectedStorage = null;
         this.isPrimary = false;
 
+        // invalidate so the connector cache rebuilds
         if (this.blockEntity.getLevel() != null  && !blockEntity.getLevel().isClientSide()) {
             this.blockEntity.getLevel().invalidateCapabilities(this.blockEntity.getBlockPos());
         }

--- a/src/main/java/com/mrh0/createaddition/compat/simulated/DockingConnectorBEAccess.java
+++ b/src/main/java/com/mrh0/createaddition/compat/simulated/DockingConnectorBEAccess.java
@@ -1,0 +1,10 @@
+package com.mrh0.createaddition.compat.simulated;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+
+public interface DockingConnectorBEAccess {
+    DockEnergyStorage getEnergyStorage();
+    BlockPos getOtherConnectorPosition();
+   // Level getLevel();
+}

--- a/src/main/java/com/mrh0/createaddition/compat/simulated/DockingConnectorBEAccess.java
+++ b/src/main/java/com/mrh0/createaddition/compat/simulated/DockingConnectorBEAccess.java
@@ -1,10 +1,5 @@
 package com.mrh0.createaddition.compat.simulated;
 
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.Level;
-
 public interface DockingConnectorBEAccess {
     DockEnergyStorage getEnergyStorage();
-    BlockPos getOtherConnectorPosition();
-   // Level getLevel();
 }

--- a/src/main/java/com/mrh0/createaddition/compat/simulated/SIMCapabilities.java
+++ b/src/main/java/com/mrh0/createaddition/compat/simulated/SIMCapabilities.java
@@ -1,0 +1,30 @@
+package com.mrh0.createaddition.compat.simulated;
+
+
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+
+public class CASimulated {
+    public static void registerBECapabilities(RegisterCapabilitiesEvent event) {
+
+        var dockType = BuiltInRegistries.BLOCK_ENTITY_TYPE.get(
+                ResourceKey.create(
+                        Registries.BLOCK_ENTITY_TYPE,
+                        ResourceLocation.fromNamespaceAndPath("simulated", "docking_connector")
+                )
+        );
+
+        if (dockType == null) {
+            return;
+        }
+        event.registerBlockEntity(
+                Capabilities.EnergyStorage.BLOCK,
+                dockType,
+                (be, side) -> ((DockingConnectorBEAccess) be).getEnergyStorage()
+        );
+    }
+}

--- a/src/main/java/com/mrh0/createaddition/compat/simulated/SIMCapabilities.java
+++ b/src/main/java/com/mrh0/createaddition/compat/simulated/SIMCapabilities.java
@@ -8,7 +8,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 
-public class CASimulated {
+public class SIMCapabilities {
     public static void registerBECapabilities(RegisterCapabilitiesEvent event) {
 
         var dockType = BuiltInRegistries.BLOCK_ENTITY_TYPE.get(

--- a/src/main/java/com/mrh0/createaddition/config/CommonConfig.java
+++ b/src/main/java/com/mrh0/createaddition/config/CommonConfig.java
@@ -24,6 +24,7 @@ public class CommonConfig {
 	public static final String CATAGORY_PEI = "portable_energy_interface";
 	public static final String CATAGORY_TESLA_COIL = "tesla_coil";
 	public static final String CATAGORY_MISC = "misc";
+	public static final String CATAGORY_COMPATIBILITY = "compatibility";
 
 	private static final ModConfigSpec.Builder COMMON_BUILDER = new ModConfigSpec.Builder();
 
@@ -83,6 +84,9 @@ public class CommonConfig {
 
 	public static ModConfigSpec.IntValue DIAMOND_GRIT_SANDPAPER_USES;
 	public static ModConfigSpec.DoubleValue BARBED_WIRE_DAMAGE;
+
+	public static ModConfigSpec.IntValue DOCKING_CONNECTOR_CAPACITY;
+
 
 	static {
 		COMMON_BUILDER.comment("Make sure config changes are duplicated on both Clients and the Server when running a dedicated Server,")
@@ -239,6 +243,11 @@ public class CommonConfig {
 		BARBED_WIRE_DAMAGE = COMMON_BUILDER.comment("Barbed Wire Damage.")
 				.defineInRange("barbed_wire_damage", 2, 0, Float.MAX_VALUE);
 
+		COMMON_BUILDER.pop();
+
+		COMMON_BUILDER.comment("Compatibility").push(CATAGORY_COMPATIBILITY);
+		DOCKING_CONNECTOR_CAPACITY = COMMON_BUILDER.comment("Energy capacity of the Docking Connector (Aeronautics/Simulated).")
+				.defineInRange("docking_connector_capacity", 80000, 1, Integer.MAX_VALUE);
 		COMMON_BUILDER.pop();
 
 		COMMON_CONFIG = COMMON_BUILDER.build();

--- a/src/main/java/com/mrh0/createaddition/index/CACapabilities.java
+++ b/src/main/java/com/mrh0/createaddition/index/CACapabilities.java
@@ -13,6 +13,8 @@ import com.mrh0.createaddition.blocks.portable_energy_interface.PortableEnergyIn
 import com.mrh0.createaddition.blocks.rolling_mill.RollingMillBlockEntity;
 import com.mrh0.createaddition.blocks.tesla_coil.TeslaCoilBlockEntity;
 import com.mrh0.createaddition.compat.computercraft.Peripherals;
+import com.mrh0.createaddition.compat.simulated.CASimulated;
+
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 
 public class CACapabilities {
@@ -31,6 +33,10 @@ public class CACapabilities {
 
         if(CreateAddition.CC_ACTIVE) {
             Peripherals.registerPeripheralCapabilities(event);
+        }
+
+        if(CreateAddition.SIM_ACTIVE) {
+            CASimulated.registerBECapabilities(event);
         }
     }
 }

--- a/src/main/java/com/mrh0/createaddition/index/CACapabilities.java
+++ b/src/main/java/com/mrh0/createaddition/index/CACapabilities.java
@@ -13,7 +13,7 @@ import com.mrh0.createaddition.blocks.portable_energy_interface.PortableEnergyIn
 import com.mrh0.createaddition.blocks.rolling_mill.RollingMillBlockEntity;
 import com.mrh0.createaddition.blocks.tesla_coil.TeslaCoilBlockEntity;
 import com.mrh0.createaddition.compat.computercraft.Peripherals;
-import com.mrh0.createaddition.compat.simulated.CASimulated;
+import com.mrh0.createaddition.compat.simulated.SIMCapabilities;
 
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 
@@ -36,7 +36,7 @@ public class CACapabilities {
         }
 
         if(CreateAddition.SIM_ACTIVE) {
-            CASimulated.registerBECapabilities(event);
+            SIMCapabilities.registerBECapabilities(event);
         }
     }
 }

--- a/src/main/java/com/mrh0/createaddition/mixin/DockingConnectorBEMixin.java
+++ b/src/main/java/com/mrh0/createaddition/mixin/DockingConnectorBEMixin.java
@@ -1,0 +1,79 @@
+package com.mrh0.createaddition.mixin;
+
+import com.mrh0.createaddition.compat.simulated.DockEnergyStorage;
+import com.mrh0.createaddition.compat.simulated.DockingConnectorBEAccess;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import com.mrh0.createaddition.config.CommonConfig;
+
+
+@Mixin(targets = "dev.simulated_team.simulated.content.blocks.docking_connector.DockingConnectorBlockEntity")
+abstract public class DockingConnectorBEMixin implements DockingConnectorBEAccess {
+    @Unique
+    private DockEnergyStorage energyStorage;
+
+    @Shadow
+    public BlockPos otherConnectorPosition;
+
+
+
+    @Inject(method = "<init>", at = @At("TAIL"), remap = false)
+    private void onInit(BlockEntityType<?> type, BlockPos pos,
+                        BlockState state, CallbackInfo ci) {
+        energyStorage = new DockEnergyStorage(
+                (BlockEntity)(Object)this,
+                CommonConfig.DOCKING_CONNECTOR_CAPACITY.getAsInt()
+        );
+    }
+    // Hook into setDock, fires alongside tank.connect()
+    @Inject(method = "setDock", at = @At(
+            value = "INVOKE",
+            target = "Ldev/simulated_team/simulated/content/blocks/docking_connector/DockingConnectorTank;connect(Lnet/minecraft/core/BlockPos;Ldev/simulated_team/simulated/content/blocks/docking_connector/DockingConnectorTank;)V"
+    ), remap = false)
+    private void onConnect(CallbackInfo ci) {
+        BlockPos otherPos = ((DockingConnectorBEAccess)(Object)this).getOtherConnectorPosition();
+        if (otherPos == null) return;
+
+        Level level = ((BlockEntity)(Object)this).getLevel();
+        if (level == null) return;
+
+        BlockEntity other = level.getBlockEntity(otherPos);
+        if (other instanceof DockingConnectorBEAccess otherAccess) {
+            this.energyStorage.connect(otherPos, otherAccess.getEnergyStorage());
+
+        }
+    }
+
+    // Hook into unDock, fires alongside tank.disconnect()
+    @Inject(
+            method = "unDock",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ldev/simulated_team/simulated/content/blocks/docking_connector/DockingConnectorTank;disconnect()V"
+            ),remap = false
+    )
+    private void onDisconnect(CallbackInfo ci) {
+
+        this.energyStorage.disconnect();
+    }
+
+    @Override
+    public DockEnergyStorage getEnergyStorage() {
+        return energyStorage;
+    }
+
+    @Override
+    public BlockPos getOtherConnectorPosition() {
+        return this.otherConnectorPosition;
+    }
+
+}

--- a/src/main/java/com/mrh0/createaddition/mixin/DockingConnectorBEMixin.java
+++ b/src/main/java/com/mrh0/createaddition/mixin/DockingConnectorBEMixin.java
@@ -24,8 +24,6 @@ abstract public class DockingConnectorBEMixin implements DockingConnectorBEAcces
     @Shadow
     public BlockPos otherConnectorPosition;
 
-
-
     @Inject(method = "<init>", at = @At("TAIL"), remap = false)
     private void onInit(BlockEntityType<?> type, BlockPos pos,
                         BlockState state, CallbackInfo ci) {
@@ -40,7 +38,7 @@ abstract public class DockingConnectorBEMixin implements DockingConnectorBEAcces
             target = "Ldev/simulated_team/simulated/content/blocks/docking_connector/DockingConnectorTank;connect(Lnet/minecraft/core/BlockPos;Ldev/simulated_team/simulated/content/blocks/docking_connector/DockingConnectorTank;)V"
     ), remap = false)
     private void onConnect(CallbackInfo ci) {
-        BlockPos otherPos = ((DockingConnectorBEAccess)(Object)this).getOtherConnectorPosition();
+        BlockPos otherPos = this.otherConnectorPosition;
         if (otherPos == null) return;
 
         Level level = ((BlockEntity)(Object)this).getLevel();
@@ -62,7 +60,6 @@ abstract public class DockingConnectorBEMixin implements DockingConnectorBEAcces
             ),remap = false
     )
     private void onDisconnect(CallbackInfo ci) {
-
         this.energyStorage.disconnect();
     }
 
@@ -71,9 +68,5 @@ abstract public class DockingConnectorBEMixin implements DockingConnectorBEAcces
         return energyStorage;
     }
 
-    @Override
-    public BlockPos getOtherConnectorPosition() {
-        return this.otherConnectorPosition;
-    }
 
 }

--- a/src/main/resources/createaddition.mixins.json
+++ b/src/main/resources/createaddition.mixins.json
@@ -9,7 +9,8 @@
         "ContraptionMixin",
         "FireBlockInvoker",
         "FireBlockMixin",
-        "FlowingFluidMixin"
+        "FlowingFluidMixin",
+        "DockingConnectorBEMixin"
     ],
     "minVersion": "0.8.5"
 }

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -66,11 +66,18 @@ AlphaMode, Skippyall, BobDole, legoatoom, gobiidaiah, StockiesLad, THEREDSTONEBR
     ordering="NONE"
     side="BOTH"
 [[dependencies.createaddition]]
+    modId="simulated"
+    type="optional"
+    ordering="AFTER"
+
+[[dependencies.createaddition]]
     modId="minecraft"
     type="required"
     # This version range declares a minimum of the current minecraft version up to but not including the next major version
     versionRange="${minecraft_version_range}"
     ordering="NONE"
+
+
 
 [[mixins]]
     config="createaddition.mixins.json"

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -69,15 +69,12 @@ AlphaMode, Skippyall, BobDole, legoatoom, gobiidaiah, StockiesLad, THEREDSTONEBR
     modId="simulated"
     type="optional"
     ordering="AFTER"
-
 [[dependencies.createaddition]]
     modId="minecraft"
     type="required"
     # This version range declares a minimum of the current minecraft version up to but not including the next major version
     versionRange="${minecraft_version_range}"
     ordering="NONE"
-
-
 
 [[mixins]]
     config="createaddition.mixins.json"


### PR DESCRIPTION
## DRAFT Pull Request 

## Pull Request Checklist

Please review and complete all items before submitting your pull request:

- [x] I have thoroughly tested the changes and verified they work as expected.
- [x] The code follows the coding standards and best practices of the project.
- [x] I have reviewed the changes for potential security or performance issues.

## MIT License Confirmation

- [x] I confirm that all code included in this PR is compatible with the [MIT License](https://opensource.org/licenses/MIT).
- [x] I understand and accept that, by submitting this pull request, all contributions are permanently licensed under the MIT License, and I waive any rights to revoke or change the license in the future.

## Description

Added better compatibility with Create Aeronautics, specifically the simulated sub mod. The feature allows the docking connectors to transfer energy to connected connectors, and other blocks.

## Related Issues

I have not yet finialized all parts. The additon in its current state works but I wanted feedback on the implemantation. I tried to stay in the same theme as other compatibility features in the repo. I also wondered how we handle version cheking. The feature should work on all current version of Aeronautics, but if changes occur it can break in the future. Should we just limit versions, or instead try to catch a potential miss match and somehow turn of the compat if that occurs.

After feedback / finalizing I would need to look at the three items in the beginning of the draft

There is a visual bug when using a spool on a simulated contraption: When holding the spool and selecting the first point the wire will look like it connects to a block far away. After selecting the second point it all looks correct. This is unrealted to my addition, but I thought it was worth to mention. (I assume it happens cuase the simulated contraption exist on another sublevel, from sable)

