### PR TITLE
[1.21.1] Add config options for liquid blaze burner, fix burn times for biofuel and blaze cakes

### DIFF
--- a/src/generated/resources/data/createaddition/recipe/liquid_burning/biofuel.json
+++ b/src/generated/resources/data/createaddition/recipe/liquid_burning/biofuel.json
@@ -1,6 +1,6 @@
 {
   "type": "createaddition:liquid_burning",
-  "burn_time": 2400,
+  "burn_time": 24000,
   "ingredients": [
     {
       "type": "neoforge:tag",

--- a/src/main/java/com/mrh0/createaddition/blocks/liquid_blaze_burner/LiquidBlazeBurnerBlockEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/liquid_blaze_burner/LiquidBlazeBurnerBlockEntity.java
@@ -326,7 +326,7 @@ public class LiquidBlazeBurnerBlockEntity extends SmartBlockEntity implements IH
 		if(tryUpdateLiquid(itemStack, simulate)) return true;
 
 		if (AllItemTags.BLAZE_BURNER_FUEL_SPECIAL.matches(itemStack)) {
-			newBurnTime = 1000;
+			newBurnTime = 3200;
 			newFuel = FuelType.SPECIAL;
 		} else {
 			newBurnTime = itemStack.getBurnTime(null);

--- a/src/main/java/com/mrh0/createaddition/blocks/liquid_blaze_burner/LiquidBlazeBurnerBlockEntity.java
+++ b/src/main/java/com/mrh0/createaddition/blocks/liquid_blaze_burner/LiquidBlazeBurnerBlockEntity.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.mrh0.createaddition.CreateAddition;
+import com.mrh0.createaddition.config.CommonConfig;
 import com.mrh0.createaddition.index.CABlockEntities;
 import com.mrh0.createaddition.index.CALang;
 import com.mrh0.createaddition.index.CARecipes;
@@ -59,7 +60,7 @@ import org.jetbrains.annotations.Nullable;
 import static com.simibubi.create.content.processing.burner.BlazeBurnerBlock.HEAT_LEVEL;
 
 public class LiquidBlazeBurnerBlockEntity extends SmartBlockEntity implements IHaveGoggleInformation, IObserveBlockEntity {
-	public static final int MAX_HEAT_CAPACITY = 10000;
+	public static int MAX_HEAT_CAPACITY = CommonConfig.LIQUID_BLAZE_BURNER_MAX_HEAT_CAPACITY.get();
 
 	protected FuelType activeFuel;
 	protected int remainingBurnTime;
@@ -111,7 +112,7 @@ public class LiquidBlazeBurnerBlockEntity extends SmartBlockEntity implements IH
 	}
 
 	protected SmartFluidTank createInventory() {
-		return new SmartFluidTank(4000, this::onFluidStackChanged);
+		return new SmartFluidTank(CommonConfig.LIQUID_BLAZE_BURNER_MAX_LIQUID_CAPACITY.get(), this::onFluidStackChanged);
 	}
 
 	protected void onFluidStackChanged(FluidStack newFluidStack) {

--- a/src/main/java/com/mrh0/createaddition/config/CommonConfig.java
+++ b/src/main/java/com/mrh0/createaddition/config/CommonConfig.java
@@ -23,6 +23,7 @@ public class CommonConfig {
 	public static final String CATAGORY_ACCUMULATOR = "accumulator";
 	public static final String CATAGORY_PEI = "portable_energy_interface";
 	public static final String CATAGORY_TESLA_COIL = "tesla_coil";
+	public static final String CATEGORY_LIQUID_BLAZE_BURNER = "liquid_blaze_burner";
 	public static final String CATAGORY_MISC = "misc";
 	public static final String CATAGORY_COMPATIBILITY = "compatibility";
 
@@ -81,6 +82,9 @@ public class CommonConfig {
 	public static ModConfigSpec.IntValue TESLA_COIL_HURT_EFFECT_TIME_MOB;
 	public static ModConfigSpec.IntValue TESLA_COIL_HURT_EFFECT_TIME_PLAYER;
 	public static ModConfigSpec.IntValue TESLA_COIL_HURT_FIRE_COOLDOWN;
+
+	public static ModConfigSpec.IntValue LIQUID_BLAZE_BURNER_MAX_LIQUID_CAPACITY;
+	public static ModConfigSpec.IntValue LIQUID_BLAZE_BURNER_MAX_HEAT_CAPACITY;
 
 	public static ModConfigSpec.IntValue DIAMOND_GRIT_SANDPAPER_USES;
 	public static ModConfigSpec.DoubleValue BARBED_WIRE_DAMAGE;
@@ -233,6 +237,14 @@ public class CommonConfig {
 
 		TESLA_COIL_HURT_FIRE_COOLDOWN = COMMON_BUILDER.comment("Tesla Coil fire interval (in ticks).")
 				.defineInRange("tesla_coil_fire_cooldown", 20, 0, Integer.MAX_VALUE);
+		COMMON_BUILDER.pop();
+
+		COMMON_BUILDER.comment("Liquid Blaze Burner").push(CATEGORY_LIQUID_BLAZE_BURNER);
+		LIQUID_BLAZE_BURNER_MAX_LIQUID_CAPACITY = COMMON_BUILDER.comment("Liquid Blaze Burner internal liquid storage capacity (in mB). A value less than 1000 prevents players from refilling with a bucket.")
+				.defineInRange("liquid_blaze_burner_max_liquid_capacity",4000,100,Integer.MAX_VALUE);
+
+		LIQUID_BLAZE_BURNER_MAX_HEAT_CAPACITY = COMMON_BUILDER.comment("Liquid Blaze Burner internal heat capacity (in ticks).")
+				.defineInRange("liquid_blaze_burner_max_heat_capacity",10000,0,Integer.MAX_VALUE);
 		COMMON_BUILDER.pop();
 
 


### PR DESCRIPTION
Add max heat capacity and max liquid capacity settings to the config file for 1.21.1. Changed blaze cake burn time from 1000 to 3200 ticks, biofuel burn time from 2400 to 24000 to be more in line with recent create mod blaze cake burn times

## Pull Request Checklist

Please review and complete all items before submitting your pull request:

- [X] I have thoroughly tested the changes and verified they work as expected.
- [X] The code follows the coding standards and best practices of the project.
- [X] I have reviewed the changes for potential security or performance issues.

## MIT License Confirmation

- [X] I confirm that all code included in this PR is compatible with the [MIT License](https://opensource.org/licenses/MIT).
- [X] I understand and accept that, by submitting this pull request, all contributions are permanently licensed under the MIT License, and I waive any rights to revoke or change the license in the future.

## Description

<!-- Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. -->

Added to config file:
- LIQUID_BLAZE_BURNER_MAX_HEAT_CAPACITY: in ticks, default 10000 (current value), range >=0
- LIQUID_BLAZE_BURNER_MAX_LIQUID_CAPACITY: in mB, default 4000 (current value), range >=100

This would enable players to configure the liquid blaze burners so that they would turn off when the liquid fuel supply is stopped (within as low as 12-24 seconds for special/superheated fuel and within 1m40s-3m20s for normal fuel when set to 0t and 100mB). It would also avoid a large fuel consumption spike when fuel is first supplied to the burners and they are initially empty and not burning.

EDIT: It seems the biofuel burn duration is currently bugged (See #1094 or commit https://github.com/mrh0/createaddition/commit/3a4b31e5412aaf9cd6abb5275f1c4a6262b0a77c), the blaze burner should turn off in the fixed situation after 2 to 4 minutes for biofuel. Blaze cake duration was also outdated (#959).

Tested in Singleplayer and Multiplayer switching config from small to large capacities (no issues), large to small capacities (temporary internal storage larger than capacity, but no other issues), combinations of small heat capacity, small liquid capacity, etc.

This would be nice to be configurable in-game (like from the bottom of the blaze burner through one or two ValueBoxTransforms) and have the config values be a maximum, but that is a design decision which I leave up to you. I can look into implementing it if you want though.

## Related Issues

<!-- List any related issues or pull requests -->

Closes issues #1159, #959, and #1094 for branch 1.21.1
