### PR TITLE
Update fr_fr.json

### DIFF
--- a/src/main/resources/assets/createaddition/lang/fr_fr.json
+++ b/src/main/resources/assets/createaddition/lang/fr_fr.json
@@ -104,7 +104,7 @@
 
 	"item.createaddition.electrum_amulet": "Amulette en électrum",
 	"item.createaddition.electrum_amulet.tooltip": "AMULETTE_EN_ÉLECTRUM",
-	"item.createaddition.electrum_amulet.tooltip.summary": "Lorsque _vous êtes au plus bas_, tenir cette _amulette_ dans votre poche vous donne l'impression que votre _chance_ va tourner.",
+	"item.createaddition.electrum_amulet.tooltip.summary": "Cette _amulette_ a un effet _\"foudroyant⚡\"_ sur les objets chargeables en Énergie Forge (Forge Energy ou FE) ! Tiens la dans ta main et elle chargera les objets dans ton autre main par à-coups..",
 
 	"item.createaddition.brass_figurine": "Figurine en laiton",
 	"item.createaddition.brass_figurine.tooltip": "FIGURINE_EN_LAITON",
@@ -312,7 +312,7 @@
 	"death.attack.barbed_wire": "%1$s a essayé de traverser des barbelés",
 	"death.attack.barbed_wire.player": "%1$s a essayé de traverser des barbelés en combattant %2$s",
 
-	"effect.createaddition.shocking": "Foudroyé",
+	"effect.createaddition.shocking": "Choc électrique",
 	"death.attack.tesla_coil": "%1$s a reçu un choc électrique mortel",
 	"death.attack.tesla_coil.player": "%1$s a reçu un choc électrique mortel alors qu'il combattait %2$s",
 	"effect.createaddition.shocking.description": "Immobilise l'entité ou joueur affecté"


### PR DESCRIPTION
## Pull Request Checklist

Please review and complete all items before submitting your pull request:

- [/] I have thoroughly tested the changes and verified they work as expected.
- [/] The code follows the coding standards and best practices of the project.
- [/] I have reviewed the changes for potential security or performance issues.

## MIT License Confirmation

- [/] I confirm that all code included in this PR is compatible with the [MIT License](https://opensource.org/licenses/MIT).
- [/] I understand and accept that, by submitting this pull request, all contributions are permanently licensed under the MIT License, and I waive any rights to revoke or change the license in the future.

## Description
Following the latest update, the Electrum Amulet has had it's purpose changed from a Speed and Luck bonus at low health to randomly charging FE-chargeable items while giving the player the "Shocked" effect. The main pupose of this PR/Commit is to update the french dub in this regard.

Also changed the fr translation of "Shocked" effect from "Foudroyé" (thunderstruck) to "Choc électrique" (electric shock), which seems clearer to me (because it could be misinterpreted as being an effect dealt only by thunder, for example).

Last but not least, it seems that the "Shocked" effect description in-game doesn't load it's translation, as it appears in English when viewed in Just Enough Effect Descriptions, but that issue might be on Just Enough Effect Descriptions's end.

## Related Issues: Electrum amulet description - Shocked effect misinterpretation

<!-- List any related issues or pull requests -->

Closes #
